### PR TITLE
[Draft] Flink Delta Source PR 12

### DIFF
--- a/flink/src/main/java/io/delta/flink/source/internal/DeltaSourceConfiguration.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/DeltaSourceConfiguration.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import io.delta.flink.source.internal.utils.DeltaConfigOption;
 import org.apache.flink.configuration.ConfigOption;
 
 /**
@@ -27,23 +28,12 @@ public class DeltaSourceConfiguration implements Serializable {
      */
     private final Map<String, Object> usedSourceOptions = new HashMap<>();
 
-    public DeltaSourceConfiguration addOption(String name, String value) {
-        return addOptionObject(name, value);
+    public DeltaSourceConfiguration addOption(String name, Object value) {
+        this.usedSourceOptions.put(name, value);
+        return this;
     }
 
-    public DeltaSourceConfiguration addOption(String name, boolean value) {
-        return addOptionObject(name, value);
-    }
-
-    public DeltaSourceConfiguration addOption(String name, int value) {
-        return addOptionObject(name, value);
-    }
-
-    public DeltaSourceConfiguration addOption(String name, long value) {
-        return addOptionObject(name, value);
-    }
-
-    public boolean hasOption(ConfigOption<?> option) {
+    public boolean hasOption(DeltaConfigOption<?> option) {
         return this.usedSourceOptions.containsKey(option.key());
     }
 
@@ -59,17 +49,12 @@ public class DeltaSourceConfiguration implements Serializable {
      * @return A value for given option if used or a default value if defined or null if none.
      */
     @SuppressWarnings("unchecked")
-    public <T> T getValue(ConfigOption<T> option) {
+    public <T> T getValue(DeltaConfigOption<T> option) {
         return (T) getValue(option.key()).orElse(option.defaultValue());
     }
 
     @SuppressWarnings("unchecked")
     private <T> Optional<T> getValue(String optionName) {
         return (Optional<T>) Optional.ofNullable(this.usedSourceOptions.get(optionName));
-    }
-
-    private DeltaSourceConfiguration addOptionObject(String name, Object value) {
-        this.usedSourceOptions.put(name, value);
-        return this;
     }
 }

--- a/flink/src/main/java/io/delta/flink/source/internal/DeltaSourceOptions.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/DeltaSourceOptions.java
@@ -3,7 +3,7 @@ package io.delta.flink.source.internal;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.flink.configuration.ConfigOption;
+import io.delta.flink.source.internal.utils.DeltaConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 
 /**
@@ -31,7 +31,7 @@ public class DeltaSourceOptions {
      * @implNote All {@code ConfigOption} defined in {@code DeltaSourceOptions} class must be added
      * to {@code VALID_SOURCE_OPTIONS} map.
      */
-    public static final Map<String, ConfigOption<?>> VALID_SOURCE_OPTIONS = new HashMap<>();
+    public static final Map<String, DeltaConfigOption<?>> VALID_SOURCE_OPTIONS = new HashMap<>();
 
     /**
      * An option that allow time travel to {@link io.delta.standalone.Snapshot} version to read
@@ -41,8 +41,10 @@ public class DeltaSourceOptions {
      * <p>
      * The String representation for this option is <b>versionAsOf</b>.
      */
-    public static final ConfigOption<Long> VERSION_AS_OF =
-        ConfigOptions.key("versionAsOf").longType().noDefaultValue();
+    public static final DeltaConfigOption<Long> VERSION_AS_OF =
+        DeltaConfigOption.of(
+            ConfigOptions.key("versionAsOf").longType().noDefaultValue(),
+            Long.class);
 
     /**
      * An option that allow time travel to the latest {@link io.delta.standalone.Snapshot} that was
@@ -53,8 +55,10 @@ public class DeltaSourceOptions {
      * <p>
      * The String representation for this option is <b>timestampAsOf</b>.
      */
-    public static final ConfigOption<String> TIMESTAMP_AS_OF =
-        ConfigOptions.key("timestampAsOf").stringType().noDefaultValue();
+    public static final DeltaConfigOption<String> TIMESTAMP_AS_OF =
+        DeltaConfigOption.of(
+            ConfigOptions.key("timestampAsOf").stringType().noDefaultValue(),
+            String.class);
 
     /**
      * An option to specify a {@link io.delta.standalone.Snapshot} version to only read changes
@@ -65,8 +69,10 @@ public class DeltaSourceOptions {
      * <p>
      * The String representation for this option is <b>startingVersion</b>.
      */
-    public static final ConfigOption<String> STARTING_VERSION =
-        ConfigOptions.key("startingVersion").stringType().noDefaultValue();
+    public static final DeltaConfigOption<String> STARTING_VERSION =
+        DeltaConfigOption.of(
+            ConfigOptions.key("startingVersion").stringType().noDefaultValue(),
+            String.class);
 
     /**
      * An option used to read only changes from {@link io.delta.standalone.Snapshot} that was
@@ -77,8 +83,10 @@ public class DeltaSourceOptions {
      * <p>
      * The String representation for this option is <b>startingTimestamp</b>.
      */
-    public static final ConfigOption<String> STARTING_TIMESTAMP =
-        ConfigOptions.key("startingTimestamp").stringType().noDefaultValue();
+    public static final DeltaConfigOption<String> STARTING_TIMESTAMP =
+        DeltaConfigOption.of(
+            ConfigOptions.key("startingTimestamp").stringType().noDefaultValue(),
+            String.class);
 
     /**
      * An option to specify check interval (in milliseconds) for monitoring Delta table changes.
@@ -89,8 +97,10 @@ public class DeltaSourceOptions {
      * The String representation for this option is <b>updateCheckIntervalMillis</b> and its default
      * value is 5000.
      */
-    public static final ConfigOption<Integer> UPDATE_CHECK_INTERVAL =
-        ConfigOptions.key("updateCheckIntervalMillis").intType().defaultValue(5000);
+    public static final DeltaConfigOption<Long> UPDATE_CHECK_INTERVAL =
+        DeltaConfigOption.of(
+            ConfigOptions.key("updateCheckIntervalMillis").longType().defaultValue(5000L),
+            Long.class);
 
     /**
      * An option to specify initial delay (in milliseconds) for starting periodical Delta table
@@ -102,8 +112,10 @@ public class DeltaSourceOptions {
      * The String representation for this option is <b>updateCheckDelayMillis</b> and its default
      * value is 1000.
      */
-    public static final ConfigOption<Integer> UPDATE_CHECK_INITIAL_DELAY =
-        ConfigOptions.key("updateCheckDelayMillis").intType().defaultValue(1000);
+    public static final DeltaConfigOption<Long> UPDATE_CHECK_INITIAL_DELAY =
+        DeltaConfigOption.of(
+            ConfigOptions.key("updateCheckDelayMillis").longType().defaultValue(1000L),
+            Long.class);
 
     /**
      * An option used to allow processing Delta table versions containing only {@link
@@ -117,8 +129,10 @@ public class DeltaSourceOptions {
      * The String representation for this option is <b>ignoreDeletes</b> and its default value is
      * false.
      */
-    public static final ConfigOption<Boolean> IGNORE_DELETES =
-        ConfigOptions.key("ignoreDeletes").booleanType().defaultValue(false);
+    public static final DeltaConfigOption<Boolean> IGNORE_DELETES =
+        DeltaConfigOption.of(
+            ConfigOptions.key("ignoreDeletes").booleanType().defaultValue(false),
+            Boolean.class);
 
     /**
      * An option used to allow processing Delta table versions containing both {@link
@@ -135,17 +149,22 @@ public class DeltaSourceOptions {
      * The String representation for this option is <b>ignoreChanges</b> and its default value is
      * false.
      */
-    public static final ConfigOption<Boolean> IGNORE_CHANGES =
-        ConfigOptions.key("ignoreChanges").booleanType().defaultValue(false);
+    public static final DeltaConfigOption<Boolean> IGNORE_CHANGES =
+        DeltaConfigOption.of(
+            ConfigOptions.key("ignoreChanges").booleanType().defaultValue(false),
+            Boolean.class);
 
     /**
      * An option to set the number of rows read per Parquet Reader per batch from underlying Parquet
      * file. This can improve read performance reducing IO cals to Parquet file at cost of memory
      * consumption on Task Manager nodes.
      */
-    public static final ConfigOption<Integer> PARQUET_BATCH_SIZE =
-        ConfigOptions.key("parquetBatchSize").intType().defaultValue(2048)
-            .withDescription("Number of rows read per batch by Parquet Reader from Parquet file.");
+    public static final DeltaConfigOption<Integer> PARQUET_BATCH_SIZE =
+        DeltaConfigOption.of(
+            ConfigOptions.key("parquetBatchSize").intType().defaultValue(2048)
+                .withDescription(
+                    "Number of rows read per batch by Parquet Reader from Parquet file."),
+            Integer.class);
 
     // TODO PR 9.1 test all allowed options
     static {

--- a/flink/src/main/java/io/delta/flink/source/internal/builder/DeltaSourceBuilderBase.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/builder/DeltaSourceBuilderBase.java
@@ -13,8 +13,8 @@ import io.delta.flink.source.internal.exceptions.DeltaSourceValidationException;
 import io.delta.flink.source.internal.file.AddFileEnumerator;
 import io.delta.flink.source.internal.file.DeltaFileEnumerator;
 import io.delta.flink.source.internal.state.DeltaSourceSplit;
+import io.delta.flink.source.internal.utils.DeltaConfigOption;
 import io.delta.flink.source.internal.utils.SourceUtils;
-import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.connector.file.src.assigners.FileSplitAssigner;
 import org.apache.flink.connector.file.src.assigners.LocalityAwareSplitAssigner;
 import org.apache.flink.core.fs.Path;
@@ -111,8 +111,10 @@ public abstract class DeltaSourceBuilderBase<T, SELF> {
      * Sets a configuration option.
      */
     public SELF option(String optionName, String optionValue) {
-        ConfigOption<?> configOption = validateOptionName(optionName);
-        sourceConfiguration.addOption(configOption.key(), optionValue);
+        DeltaConfigOption<?> configOption = validateOptionName(optionName);
+        Object convertedValue = OptionTypeConverter.convertType(configOption, optionValue);
+
+        sourceConfiguration.addOption(configOption.key(), convertedValue);
         return self();
     }
 
@@ -120,8 +122,10 @@ public abstract class DeltaSourceBuilderBase<T, SELF> {
      * Sets a configuration option.
      */
     public SELF option(String optionName, boolean optionValue) {
-        ConfigOption<?> configOption = validateOptionName(optionName);
-        sourceConfiguration.addOption(configOption.key(), optionValue);
+        DeltaConfigOption<?> configOption = validateOptionName(optionName);
+        Object convertedValue = OptionTypeConverter.convertType(configOption, optionValue);
+
+        sourceConfiguration.addOption(configOption.key(), convertedValue);
         return self();
     }
 
@@ -129,8 +133,10 @@ public abstract class DeltaSourceBuilderBase<T, SELF> {
      * Sets a configuration option.
      */
     public SELF option(String optionName, int optionValue) {
-        ConfigOption<?> configOption = validateOptionName(optionName);
-        sourceConfiguration.addOption(configOption.key(), optionValue);
+        DeltaConfigOption<?> configOption = validateOptionName(optionName);
+        Object convertedValue = OptionTypeConverter.convertType(configOption, optionValue);
+
+        sourceConfiguration.addOption(configOption.key(), convertedValue);
         return self();
     }
 
@@ -138,8 +144,10 @@ public abstract class DeltaSourceBuilderBase<T, SELF> {
      * Sets a configuration option.
      */
     public SELF option(String optionName, long optionValue) {
-        ConfigOption<?> configOption = validateOptionName(optionName);
-        sourceConfiguration.addOption(configOption.key(), optionValue);
+        DeltaConfigOption<?> configOption = validateOptionName(optionName);
+        Object convertedValue = OptionTypeConverter.convertType(configOption, optionValue);
+
+        sourceConfiguration.addOption(configOption.key(), convertedValue);
         return self();
     }
 
@@ -215,8 +223,8 @@ public abstract class DeltaSourceBuilderBase<T, SELF> {
     }
 
     // TODO Refactor Option name validation in PR 9.1
-    protected ConfigOption<?> validateOptionName(String optionName) {
-        ConfigOption<?> option = DeltaSourceOptions.VALID_SOURCE_OPTIONS.get(optionName);
+    protected DeltaConfigOption<?> validateOptionName(String optionName) {
+        DeltaConfigOption<?> option = DeltaSourceOptions.VALID_SOURCE_OPTIONS.get(optionName);
         if (option == null) {
             throw DeltaSourceExceptions.invalidOptionNameException(
                 SourceUtils.pathToString(tablePath), optionName);

--- a/flink/src/main/java/io/delta/flink/source/internal/builder/FormatBuilder.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/builder/FormatBuilder.java
@@ -14,4 +14,6 @@ public interface FormatBuilder<T> {
     FormatBuilder<T> partitionColumns(List<String> partitionColumns);
 
     FormatBuilder<T> partitionColumns(String... partitionColumns);
+
+    FormatBuilder<T> parquetBatchSize(int size);
 }

--- a/flink/src/main/java/io/delta/flink/source/internal/builder/OptionType.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/builder/OptionType.java
@@ -1,0 +1,43 @@
+package io.delta.flink.source.internal.builder;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An Enum supported Java types for {@link io.delta.flink.source.internal.DeltaSourceOptions}.
+ *
+ * <p>
+ * This Enum can be used for example to build switch statement based on {@link Class} type.
+ */
+public enum OptionType {
+    STRING(String.class),
+    BOOLEAN(Boolean.class),
+    INTEGER(Integer.class),
+    LONG(Long.class),
+    OTHER(null);
+
+    private static final Map<Class<?>, OptionType> LOOKUP_MAP;
+
+    static {
+        Map<Class<?>, OptionType> tmpMap = new HashMap<>();
+        for (OptionType type : OptionType.values()) {
+            tmpMap.put(type.optionType, type);
+        }
+        LOOKUP_MAP = Collections.unmodifiableMap(tmpMap);
+    }
+
+    private final Class<?> optionType;
+
+    OptionType(Class<?> optionType) {
+        this.optionType = optionType;
+    }
+
+    /**
+     * @param optionType A desired Java {@link Class} type
+     * @return mapped instance of {@link OptionType} Enum.
+     */
+    public static OptionType instanceFrom(Class<?> optionType) {
+        return LOOKUP_MAP.getOrDefault(optionType, OTHER);
+    }
+}

--- a/flink/src/main/java/io/delta/flink/source/internal/builder/OptionTypeConverter.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/builder/OptionTypeConverter.java
@@ -1,0 +1,52 @@
+package io.delta.flink.source.internal.builder;
+
+import io.delta.flink.source.internal.utils.DeltaConfigOption;
+
+// TODO PR 10 add Javadoc and tests
+
+/**
+ * A utility class to convert {@link DeltaConfigOption} values to desired {@link Class} type.
+ */
+public final class OptionTypeConverter {
+
+    private OptionTypeConverter() {
+    }
+
+    /**
+     * Converts an integer value to desired type of {@link DeltaConfigOption#getDecoratedType()}.
+     *
+     * @param option A {@link DeltaConfigOption} for given value.
+     * @param value  A value that type should be converted.
+     * @param <T>    A type to which "value" parameter will be converted to.
+     * @return value with converted type to {@link DeltaConfigOption#getDecoratedType()}.
+     */
+    public static <T> T convertType(DeltaConfigOption<T> option, Integer value) {
+        return convertType(option, String.valueOf(value));
+    }
+
+    public static <T> T convertType(DeltaConfigOption<T> option, Long value) {
+        return convertType(option, String.valueOf(value));
+    }
+
+    public static <T> T convertType(DeltaConfigOption<T> option, Boolean value) {
+        return convertType(option, String.valueOf(value));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T convertType(DeltaConfigOption<T> option, String value) {
+        Class<T> decoratedType = option.getDecoratedType();
+        OptionType type = OptionType.instanceFrom(decoratedType);
+        switch (type) {
+            case STRING:
+                return (T) value;
+            case BOOLEAN:
+                return (T) Boolean.valueOf(value);
+            case INTEGER:
+                return (T) Integer.valueOf(value);
+            case LONG:
+                return (T) Long.valueOf(value);
+            default:
+                throw new RuntimeException("Ehh...");
+        }
+    }
+}

--- a/flink/src/main/java/io/delta/flink/source/internal/enumerator/supplier/SnapshotSupplier.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/enumerator/supplier/SnapshotSupplier.java
@@ -1,8 +1,8 @@
 package io.delta.flink.source.internal.enumerator.supplier;
 
 import io.delta.flink.source.internal.DeltaSourceConfiguration;
+import io.delta.flink.source.internal.utils.DeltaConfigOption;
 import io.delta.flink.source.internal.utils.TransitiveOptional;
-import org.apache.flink.configuration.ConfigOption;
 
 import io.delta.standalone.DeltaLog;
 import io.delta.standalone.Snapshot;
@@ -53,7 +53,7 @@ public abstract class SnapshotSupplier {
      * A helper method to get the value of {@link io.delta.flink.source.internal.DeltaSourceOptions}
      * from {@link #sourceConfiguration}.
      */
-    protected <T> T getOptionValue(ConfigOption<T> option) {
+    protected <T> T getOptionValue(DeltaConfigOption<T> option) {
         return this.sourceConfiguration.getValue(option);
     }
 }

--- a/flink/src/main/java/io/delta/flink/source/internal/utils/DeltaConfigOption.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/utils/DeltaConfigOption.java
@@ -1,0 +1,31 @@
+package io.delta.flink.source.internal.utils;
+
+import org.apache.flink.configuration.ConfigOption;
+
+public class DeltaConfigOption<T> {
+
+    private final ConfigOption<T> decoratedOption;
+
+    private final Class<T> decoratedType;
+
+    private DeltaConfigOption(ConfigOption<T> decoratedOption, Class<T> type) {
+        this.decoratedOption = decoratedOption;
+        this.decoratedType = type;
+    }
+
+    public static <T> DeltaConfigOption<T> of(ConfigOption<T> configOption, Class<T> type) {
+        return new DeltaConfigOption<>(configOption, type);
+    }
+
+    public Class<T> getDecoratedType() {
+        return decoratedType;
+    }
+
+    public String key() {
+        return decoratedOption.key();
+    }
+
+    public T defaultValue() {
+        return decoratedOption.defaultValue();
+    }
+}

--- a/flink/src/test/java/io/delta/flink/source/DeltaSourceContinuousExecutionITCaseTest.java
+++ b/flink/src/test/java/io/delta/flink/source/DeltaSourceContinuousExecutionITCaseTest.java
@@ -135,7 +135,7 @@ public class DeltaSourceContinuousExecutionITCaseTest extends DeltaSourceITBase 
 
     @ParameterizedTest(name = "{index}: FailoverType = [{0}]")
     @EnumSource(FailoverType.class)
-    // This test updates Delta Table 5 times, so it will take some time to finish. About 1 minute.
+    // This test updates Delta Table 5 times, so it will take some time to finish.
     public void shouldReadDeltaTableFromSnapshotAndUpdates(FailoverType failoverType)
         throws Exception {
 

--- a/flink/src/test/java/io/delta/flink/source/RowDataBoundedDeltaSourceBuilderTest.java
+++ b/flink/src/test/java/io/delta/flink/source/RowDataBoundedDeltaSourceBuilderTest.java
@@ -45,7 +45,7 @@ class RowDataBoundedDeltaSourceBuilderTest extends RowDataDeltaSourceBuilderTest
         assertThat(boundedSource, notNullValue());
         assertThat(boundedSource.getBoundedness(), equalTo(Boundedness.BOUNDED));
         assertThat(boundedSource.getSourceConfiguration()
-            .getValue(DeltaSourceOptions.VERSION_AS_OF), equalTo(10));
+            .getValue(DeltaSourceOptions.VERSION_AS_OF), equalTo(10L));
     }
 
     //////////////////////////////////////////////////////////////

--- a/flink/src/test/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilderTest.java
+++ b/flink/src/test/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilderTest.java
@@ -45,7 +45,7 @@ class RowDataContinuousDeltaSourceBuilderTest extends RowDataDeltaSourceBuilderT
         assertThat(boundedSource, notNullValue());
         assertThat(boundedSource.getBoundedness(), equalTo(Boundedness.CONTINUOUS_UNBOUNDED));
         assertThat(boundedSource.getSourceConfiguration()
-            .getValue(DeltaSourceOptions.STARTING_TIMESTAMP), equalTo(10));
+            .getValue(DeltaSourceOptions.STARTING_TIMESTAMP), equalTo("10"));
     }
 
     //////////////////////////////////////////////////////////////

--- a/flink/src/test/java/io/delta/flink/source/internal/DeltaSourceConfigurationTest.java
+++ b/flink/src/test/java/io/delta/flink/source/internal/DeltaSourceConfigurationTest.java
@@ -2,7 +2,7 @@ package io.delta.flink.source.internal;
 
 import java.util.UUID;
 
-import org.apache.flink.configuration.ConfigOption;
+import io.delta.flink.source.internal.utils.DeltaConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.junit.Before;
 import org.junit.Test;
@@ -68,21 +68,29 @@ public class DeltaSourceConfigurationTest {
 
     static class TestOptions {
 
-        static final ConfigOption<Long> LONG_OPTION =
-            ConfigOptions.key("longOption").longType().defaultValue(Long.MAX_VALUE);
+        static final DeltaConfigOption<Long> LONG_OPTION =
+            DeltaConfigOption.of(
+                ConfigOptions.key("longOption").longType().defaultValue(Long.MAX_VALUE),
+                Long.class);
 
-        static final ConfigOption<Integer> INT_OPTION =
-            ConfigOptions.key("intOption").intType().defaultValue(Integer.MAX_VALUE);
+        static final DeltaConfigOption<Integer> INT_OPTION =
+            DeltaConfigOption.of(
+                ConfigOptions.key("intOption").intType().defaultValue(Integer.MAX_VALUE),
+                Integer.class);
 
-        static final ConfigOption<String> STRING_OPTION =
-            ConfigOptions.key("stringOption").stringType()
-                .defaultValue(UUID.randomUUID().toString());
+        static final DeltaConfigOption<String> STRING_OPTION =
+            DeltaConfigOption.of(ConfigOptions.key("stringOption").stringType()
+                    .defaultValue(UUID.randomUUID().toString()),
+                String.class);
 
-        static final ConfigOption<Boolean> BOOLEAN_OPTION =
-            ConfigOptions.key("booleanOption").booleanType().defaultValue(false);
+        static final DeltaConfigOption<Boolean> BOOLEAN_OPTION =
+            DeltaConfigOption.of(
+                ConfigOptions.key("booleanOption").booleanType().defaultValue(false),
+                Boolean.class);
 
-        static final ConfigOption<Boolean> NO_DEFAULT_VALUE =
-            ConfigOptions.key("noDefault").booleanType().noDefaultValue();
+        static final DeltaConfigOption<Boolean> NO_DEFAULT_VALUE =
+            DeltaConfigOption.of(ConfigOptions.key("noDefault").booleanType().noDefaultValue(),
+                Boolean.class);
     }
 
 }

--- a/flink/src/test/java/io/delta/flink/source/internal/DeltaSourceOptionsTest.java
+++ b/flink/src/test/java/io/delta/flink/source/internal/DeltaSourceOptionsTest.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import static java.lang.reflect.Modifier.isPublic;
 import static java.lang.reflect.Modifier.isStatic;
 
+import io.delta.flink.source.internal.utils.DeltaConfigOption;
 import org.apache.flink.configuration.ConfigOption;
 import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,7 +39,7 @@ public class DeltaSourceOptionsTest {
     }
 
     private boolean isConfigOptionField(Field field) {
-        return field.getType().equals(ConfigOption.class);
+        return field.getType().equals(DeltaConfigOption.class);
     }
 
     private boolean isPublicStatic(Field field) {


### PR DESCRIPTION
PR Plan:
PR 5 - Option support in Bounded Mode - **DONE**
PR 6 - Continuous mode without monitoring for changes - **DONE**
PR 6.1 - Package Refactoring - **DONE**
PR 7 - Monitoring for changes in Continuous mode - **DONE**
PR 7.1 - More tests for PR 7 including IT case tests for Continuous mode. - **DONE**
PR 9 - Builder - **DONE**
PR 10 - Builder refactoring to extract Schema from Delta Log. - **DONE**
PR 10.1 - Tests for SourceUtils::buildSourceSchema, DeltaSourceBuilderBase::getSourceSchema and SnapshotSupplier implementations. - **DONE**
**PR 11 - Partition Support using Delta log to identify partition columns.**
PR 12 - Get BATCH_SIZE for Format builder from Source options - this value is currently hardcoded. Add validation for option names and values including using not applicable options for given mode via generic option method.

-- All functionalities are in place up to this point. The following PRs are extra tests, eventual bug fixes and code/javadoc adjustments. --

~~PR 11 - Annotate with @deprecated  Sink's builder methods that names starts from "with". Add new ones without "with" prefix and overload partitions with List argument for Sink.~~

PR 13 - Additional IT tests including all options (startingVersion, versionAsOf etc), end2end tests using Source and Sink, end2end verifying reading only userColumnNames.

While @kristoffSC is on vacation
@tdas + @scottsand-db to review public API
Once Krzysztof is back
README / docs
QA
end-to-end integration tests - using Sink to write, Source to read, etc.
more examples / migrate examples from internal flink module to examples folder

TODOs and other improvements planed as next:

- Use index for keeping track of already processed paths in SnapshotProcessor - needs new Delta API.
- Do do not create snapshot when streaming only changes (startingVersion or startingTimestamp option used). - needs new Delta API since for startingTimestamp we still need to create a snapshot. There is no API like deltaLog.getChangesFromTimestamp(....)
- Refactor Test util classes to make them common for sink and source.
- Re-visit Delta Standalone APIs for when the source see's metadata/protocol actions. Update ActionProcessor class to handle MetaData and Protocol Actions
- Enhanced DeltaLog.java with a new method similaiar `todeltaLog.getSnapshotForVersionAsOf()` but for streaming mode. Use it in Delta Source connector for `startingTimestamp` option. -> https://github.com/delta-io/connectors/pull/346