### PR TITLE
[Draft] PR 10 - get table schema from Delta Log.

### DIFF
--- a/flink/src/main/java/io/delta/flink/source/DeltaSource.java
+++ b/flink/src/main/java/io/delta/flink/source/DeltaSource.java
@@ -2,15 +2,14 @@ package io.delta.flink.source;
 
 import io.delta.flink.source.internal.DeltaSourceConfiguration;
 import io.delta.flink.source.internal.DeltaSourceInternal;
-import io.delta.flink.source.internal.builder.RowDataFormat;
-import io.delta.flink.source.internal.builder.RowDataFormatBuilder;
 import io.delta.flink.source.internal.enumerator.SplitEnumeratorProvider;
+import io.delta.flink.source.internal.enumerator.supplier.BoundedSnapshotSupplierFactory;
+import io.delta.flink.source.internal.enumerator.supplier.ContinuousSnapshotSupplierFactory;
 import io.delta.flink.source.internal.state.DeltaSourceSplit;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.hadoop.conf.Configuration;
 
 import io.delta.standalone.actions.AddFile;
@@ -76,38 +75,31 @@ import io.delta.standalone.actions.AddFile;
 public class DeltaSource<T> extends DeltaSourceInternal<T> {
 
     DeltaSource(
-        Path tablePath,
-        BulkFormat<T, DeltaSourceSplit> readerFormat,
-        SplitEnumeratorProvider splitEnumeratorProvider,
-        Configuration configuration,
-        DeltaSourceConfiguration sourceConfiguration) {
+            Path tablePath,
+            BulkFormat<T, DeltaSourceSplit> readerFormat,
+            SplitEnumeratorProvider splitEnumeratorProvider,
+            Configuration configuration,
+            DeltaSourceConfiguration sourceConfiguration) {
         super(tablePath, readerFormat, splitEnumeratorProvider, configuration, sourceConfiguration);
     }
 
     public static RowDataBoundedDeltaSourceBuilder forBoundedRowData(
-        Path tablePath,
-        String[] columnNames,
-        LogicalType[] columnTypes,
-        Configuration hadoopConfiguration) {
+            Path tablePath,
+            Configuration hadoopConfiguration) {
 
-        RowDataFormatBuilder formatBuilder = RowDataFormat
-            .builder(columnNames, columnTypes, hadoopConfiguration);
-
-        return new RowDataBoundedDeltaSourceBuilder(tablePath, formatBuilder, hadoopConfiguration);
+        return new RowDataBoundedDeltaSourceBuilder(
+            tablePath,
+            hadoopConfiguration,
+            new BoundedSnapshotSupplierFactory());
     }
 
     public static RowDataContinuousDeltaSourceBuilder forContinuousRowData(
-        Path tablePath,
-        String[] columnNames,
-        LogicalType[] columnTypes,
-        Configuration hadoopConfiguration) {
-
-        RowDataFormatBuilder formatBuilder = RowDataFormat
-            .builder(columnNames, columnTypes, hadoopConfiguration);
+            Path tablePath,
+            Configuration hadoopConfiguration) {
 
         return new RowDataContinuousDeltaSourceBuilder(
-            tablePath,
-            formatBuilder,
-            hadoopConfiguration);
+                tablePath,
+                hadoopConfiguration,
+                new ContinuousSnapshotSupplierFactory());
     }
 }

--- a/flink/src/main/java/io/delta/flink/source/internal/DeltaDataType.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/DeltaDataType.java
@@ -1,0 +1,63 @@
+package io.delta.flink.source.internal;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.delta.standalone.types.ArrayType;
+import io.delta.standalone.types.BinaryType;
+import io.delta.standalone.types.BooleanType;
+import io.delta.standalone.types.ByteType;
+import io.delta.standalone.types.DataType;
+import io.delta.standalone.types.DateType;
+import io.delta.standalone.types.DecimalType;
+import io.delta.standalone.types.DoubleType;
+import io.delta.standalone.types.FloatType;
+import io.delta.standalone.types.IntegerType;
+import io.delta.standalone.types.LongType;
+import io.delta.standalone.types.MapType;
+import io.delta.standalone.types.NullType;
+import io.delta.standalone.types.ShortType;
+import io.delta.standalone.types.StringType;
+import io.delta.standalone.types.StructType;
+import io.delta.standalone.types.TimestampType;
+
+public enum DeltaDataType {
+    ARRAY(ArrayType.class),
+    BIGINT(LongType.class),
+    VAR_BINARY(BinaryType.class),
+    BOOLEAN(BooleanType.class),
+    DATE(DateType.class),
+    DECIMAL(DecimalType.class),
+    DOUBLE(DoubleType.class),
+    FLOAT(FloatType.class),
+    INTEGER(IntegerType.class),
+    MAP(MapType.class),
+    NULL(NullType.class),
+    SMALLINT(ShortType.class),
+    TIMESTAMP(TimestampType.class),
+    TINYINT(ByteType.class),
+    VAR_CHAR(StringType.class),
+    ROW(StructType.class),
+    OTHER(null);
+
+    private static final Map<Class<?>, DeltaDataType> LOOKUP_MAP;
+
+    static {
+        Map<Class<?>, DeltaDataType> tmpMap = new HashMap<>();
+        for (DeltaDataType type : DeltaDataType.values()) {
+            tmpMap.put(type.deltaDataTypeClass, type);
+        }
+        LOOKUP_MAP = Collections.unmodifiableMap(tmpMap);
+    }
+
+    private final Class<? extends DataType> deltaDataTypeClass;
+
+    DeltaDataType(Class<? extends DataType> deltaDataTypeClass) {
+        this.deltaDataTypeClass = deltaDataTypeClass;
+    }
+
+    public static DeltaDataType instanceFrom(Class<? extends DataType> deltaActionName) {
+        return LOOKUP_MAP.getOrDefault(deltaActionName, OTHER);
+    }
+}

--- a/flink/src/main/java/io/delta/flink/source/internal/SchemaConverter.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/SchemaConverter.java
@@ -1,0 +1,69 @@
+package io.delta.flink.source.internal;
+
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.NullType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+
+import io.delta.standalone.types.ArrayType;
+import io.delta.standalone.types.DataType;
+
+public class SchemaConverter {
+
+    public static LogicalType toFlinkDataType(DataType deltaType) {
+
+        DeltaDataType deltaDataType = DeltaDataType.instanceFrom(deltaType.getClass());
+        switch (deltaDataType) {
+            case ARRAY:
+                boolean containsNull = ((ArrayType) deltaType).containsNull();
+                LogicalType elementType = toFlinkDataType(((ArrayType) deltaType).getElementType());
+                return
+                    new org.apache.flink.table.types.logical.ArrayType(containsNull, elementType);
+            case BIGINT:
+                return new BigIntType();
+            case VAR_BINARY:
+                return new BinaryType();
+            case BOOLEAN:
+                return new BooleanType();
+            case DATE:
+                return new DateType();
+            case DECIMAL:
+                return new DecimalType();
+            case DOUBLE:
+                return new DoubleType();
+            case FLOAT:
+                return new FloatType();
+            case INTEGER:
+                return new IntType();
+            case MAP:
+                // TODO
+            case NULL:
+                return new NullType();
+            case SMALLINT:
+                return new SmallIntType();
+            case TIMESTAMP:
+                return new TimestampType();
+            case TINYINT:
+                return new TinyIntType();
+            case VAR_CHAR:
+                return new CharType();
+
+            default:
+                throw new UnsupportedOperationException(
+                    "Type not supported: " + deltaDataType);
+        }
+
+
+    }
+
+}

--- a/flink/src/main/java/io/delta/flink/source/internal/builder/BoundedDeltaSourceBuilder.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/builder/BoundedDeltaSourceBuilder.java
@@ -1,6 +1,7 @@
 package io.delta.flink.source.internal.builder;
 
 import io.delta.flink.source.internal.enumerator.BoundedSplitEnumeratorProvider;
+import io.delta.flink.source.internal.enumerator.supplier.BoundedSnapshotSupplierFactory;
 import org.apache.flink.core.fs.Path;
 import org.apache.hadoop.conf.Configuration;
 import static io.delta.flink.source.internal.DeltaSourceOptions.TIMESTAMP_AS_OF;
@@ -27,9 +28,11 @@ public abstract class BoundedDeltaSourceBuilder<T, SELF> extends DeltaSourceBuil
         new BoundedSplitEnumeratorProvider(DEFAULT_SPLIT_ASSIGNER,
             DEFAULT_SPLITTABLE_FILE_ENUMERATOR);
 
-    public BoundedDeltaSourceBuilder(Path tablePath,
-        FormatBuilder<T> formatBuilder, Configuration hadoopConfiguration) {
-        super(tablePath, formatBuilder, hadoopConfiguration);
+    public BoundedDeltaSourceBuilder(
+            Path tablePath,
+            Configuration hadoopConfiguration,
+            BoundedSnapshotSupplierFactory snapshotSupplierFactory) {
+        super(tablePath, hadoopConfiguration, snapshotSupplierFactory);
     }
 
     // TODO PR 9.1 add tests for options.

--- a/flink/src/main/java/io/delta/flink/source/internal/builder/ContinuousDeltaSourceBuilder.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/builder/ContinuousDeltaSourceBuilder.java
@@ -1,6 +1,7 @@
 package io.delta.flink.source.internal.builder;
 
 import io.delta.flink.source.internal.enumerator.ContinuousSplitEnumeratorProvider;
+import io.delta.flink.source.internal.enumerator.supplier.ContinuousSnapshotSupplierFactory;
 import org.apache.flink.core.fs.Path;
 import org.apache.hadoop.conf.Configuration;
 import static io.delta.flink.source.internal.DeltaSourceOptions.IGNORE_CHANGES;
@@ -31,9 +32,11 @@ public abstract class ContinuousDeltaSourceBuilder<T, SELF>
         new ContinuousSplitEnumeratorProvider(DEFAULT_SPLIT_ASSIGNER,
             DEFAULT_SPLITTABLE_FILE_ENUMERATOR);
 
-    public ContinuousDeltaSourceBuilder(Path tablePath,
-        FormatBuilder<T> formatBuilder, Configuration hadoopConfiguration) {
-        super(tablePath, formatBuilder, hadoopConfiguration);
+    public ContinuousDeltaSourceBuilder(
+            Path tablePath,
+            Configuration hadoopConfiguration,
+            ContinuousSnapshotSupplierFactory snapshotSupplierFactory) {
+        super(tablePath, hadoopConfiguration, snapshotSupplierFactory);
     }
     // TODO PR 9.1 add tests for options.
     public SELF startingVersion(String startingVersion) {

--- a/flink/src/main/java/io/delta/flink/source/internal/builder/DeltaSourceBuilderBase.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/builder/DeltaSourceBuilderBase.java
@@ -1,24 +1,30 @@
 package io.delta.flink.source.internal.builder;
 
-import java.util.Collection;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
 import io.delta.flink.source.DeltaSource;
 import io.delta.flink.source.internal.DeltaSourceConfiguration;
 import io.delta.flink.source.internal.DeltaSourceOptions;
+import io.delta.flink.source.internal.enumerator.supplier.SnapshotSupplier;
+import io.delta.flink.source.internal.enumerator.supplier.SnapshotSupplierFactory;
 import io.delta.flink.source.internal.exceptions.DeltaSourceExceptions;
 import io.delta.flink.source.internal.exceptions.DeltaSourceValidationException;
 import io.delta.flink.source.internal.file.AddFileEnumerator;
 import io.delta.flink.source.internal.file.DeltaFileEnumerator;
 import io.delta.flink.source.internal.state.DeltaSourceSplit;
+import io.delta.flink.source.internal.utils.SourceSchema;
 import io.delta.flink.source.internal.utils.SourceUtils;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.connector.file.src.assigners.FileSplitAssigner;
 import org.apache.flink.connector.file.src.assigners.LocalityAwareSplitAssigner;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.StringUtils;
 import org.apache.hadoop.conf.Configuration;
+
+import io.delta.standalone.Snapshot;
+import io.delta.standalone.types.StructType;
 
 /**
  * The base class for {@link io.delta.flink.source.DeltaSource} builder.
@@ -55,6 +61,11 @@ public abstract class DeltaSourceBuilderBase<T, SELF> {
         DEFAULT_SPLITTABLE_FILE_ENUMERATOR = DeltaFileEnumerator::new;
 
     /**
+     * Default reference value for column names list.
+     */
+    protected static final List<String> DEFAULT_COLUMNS = new ArrayList<>(0);
+
+    /**
      * Message prefix for validation exceptions.
      */
     protected static final String EXCEPTION_PREFIX = "DeltaSourceBuilder - ";
@@ -64,35 +75,35 @@ public abstract class DeltaSourceBuilderBase<T, SELF> {
      * instance.
      */
     protected final DeltaSourceConfiguration sourceConfiguration = new DeltaSourceConfiguration();
-
     /**
      * A {@link Path} to Delta table that should be read by created {@link
      * io.delta.flink.source.DeltaSource}.
      */
     protected final Path tablePath;
-
-    /**
-     * An instance of {@link FormatBuilder} that will be used to build {@link DeltaBulkFormat}
-     * instance.
-     */
-    protected final FormatBuilder<T> formatBuilder;
-
     /**
      * The Hadoop's {@link Configuration} for this Source.
      */
     protected final Configuration hadoopConfiguration;
 
+    protected final SnapshotSupplierFactory snapshotSupplierFactory;
+
+    /**
+     * An array with Delta table's column names that should be read.
+     */
+    protected List<String> userColumnNames;
+
     protected DeltaSourceBuilderBase(
             Path tablePath,
-            FormatBuilder<T> formatBuilder,
-            Configuration hadoopConfiguration) {
+            Configuration hadoopConfiguration,
+            SnapshotSupplierFactory snapshotSupplierFactory) {
         this.tablePath = tablePath;
-        this.formatBuilder = formatBuilder;
         this.hadoopConfiguration = hadoopConfiguration;
+        this.snapshotSupplierFactory = snapshotSupplierFactory;
+        this.userColumnNames = DEFAULT_COLUMNS;
     }
 
-    public SELF partitionColumns(List<String> partitions) {
-        formatBuilder.partitionColumns(partitions);
+    public SELF columnNames(List<String> columnNames) {
+        this.userColumnNames = columnNames;
         return self();
     }
 
@@ -142,45 +153,18 @@ public abstract class DeltaSourceBuilderBase<T, SELF> {
     protected abstract Validator validateOptionExclusions();
 
     /**
-     * Validates {@link FormatBuilder} and returns new instance of {@link DeltaBulkFormat}.
-     *
-     * @return {@link DeltaBulkFormat} instance.
-     * @throws DeltaSourceValidationException if {@link FormatBuilder} definition has anny
-     *                                        validation issues.
-     */
-    protected DeltaBulkFormat<T> validateSourceAndFormat() {
-        DeltaBulkFormat<T> format = null;
-        Collection<String> formatValidationMessages = Collections.emptySet();
-        try {
-            format = formatBuilder.build();
-        } catch (DeltaSourceValidationException e) {
-            formatValidationMessages = e.getValidationMessages();
-        }
-        validateSource(formatValidationMessages);
-        return format;
-    }
-
-    /**
      * Validate definition of Delta source builder including mandatory and optional options.
-     *
-     * @param extraValidationMessages other validation messages that should be included in this
-     *                                validation check. If collection is not empty, the {@link
-     *                                DeltaSourceValidationException} will be thrown.
      */
-    protected void validateSource(Collection<String> extraValidationMessages) {
+    protected void validate() {
         Validator mandatoryValidator = validateMandatoryOptions();
         Validator exclusionsValidator = validateOptionExclusions();
+        Validator optionalValidator = validateOptionalParameters();
 
         List<String> validationMessages = new LinkedList<>();
-        if (mandatoryValidator.containsMessages() || exclusionsValidator.containsMessages()) {
 
-            validationMessages.addAll(mandatoryValidator.getValidationMessages());
-            validationMessages.addAll(exclusionsValidator.getValidationMessages());
-        }
-
-        if (extraValidationMessages != null) {
-            validationMessages.addAll(extraValidationMessages);
-        }
+        validationMessages.addAll(mandatoryValidator.getValidationMessages());
+        validationMessages.addAll(exclusionsValidator.getValidationMessages());
+        validationMessages.addAll(optionalValidator.getValidationMessages());
 
         if (!validationMessages.isEmpty()) {
             String tablePathString =
@@ -197,6 +181,29 @@ public abstract class DeltaSourceBuilderBase<T, SELF> {
             .checkNotNull(hadoopConfiguration, EXCEPTION_PREFIX + "missing Hadoop configuration.");
     }
 
+    protected Validator validateOptionalParameters() {
+        Validator validator = new Validator();
+
+        if (userColumnNames != DEFAULT_COLUMNS) {
+            validator.checkNotNull(userColumnNames,
+                EXCEPTION_PREFIX + "used a null reference for user columns.");
+
+            if (userColumnNames != null) {
+                validator.checkArgument(!userColumnNames.isEmpty(),
+                    EXCEPTION_PREFIX + "user column names list is empty.");
+                if (!userColumnNames.isEmpty()) {
+                    validator.checkArgument(
+                        userColumnNames.stream().noneMatch(StringUtils::isNullOrWhitespaceOnly),
+                        EXCEPTION_PREFIX
+                            + "user column names list contains at least one element that is null, "
+                            + "empty, or has only whitespace characters.");
+                }
+            }
+        }
+
+        return validator;
+    }
+
     protected String prepareOptionExclusionMessage(String... mutualExclusiveOptions) {
         return String.format(
             "Used mutually exclusive options for Source definition. Invalid options [%s]",
@@ -211,6 +218,17 @@ public abstract class DeltaSourceBuilderBase<T, SELF> {
                 SourceUtils.pathToString(tablePath), optionName);
         }
         return option;
+    }
+
+    protected SourceSchema getSourceSchema(SnapshotSupplier snapshotSupplier) {
+        Snapshot snapshot = snapshotSupplier.getSnapshot(sourceConfiguration);
+        StructType tableSchema = snapshot.getMetadata().getSchema();
+        if (tableSchema == null) {
+            // TODO
+            throw new RuntimeException("No Delta Schema");
+        }
+
+        return SourceUtils.buildSourceSchema(userColumnNames, tableSchema);
     }
 
     @SuppressWarnings("unchecked")

--- a/flink/src/main/java/io/delta/flink/source/internal/builder/RowDataFormat.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/builder/RowDataFormat.java
@@ -3,7 +3,6 @@ package io.delta.flink.source.internal.builder;
 import io.delta.flink.source.internal.state.DeltaSourceSplit;
 import org.apache.flink.formats.parquet.ParquetColumnarRowInputFormat;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.hadoop.conf.Configuration;
 
@@ -19,8 +18,7 @@ public class RowDataFormat extends ParquetColumnarRowInputFormat<DeltaSourceSpli
         super(hadoopConfig, projectedType, batchSize, isUtcTimestamp, isCaseSensitive);
     }
 
-    public static RowDataFormatBuilder builder(
-        String[] columnNames, LogicalType[] columnTypes, Configuration hadoopConfiguration) {
-        return new RowDataFormatBuilder(columnNames, columnTypes, hadoopConfiguration);
+    public static RowDataFormatBuilder builder(RowType rowType, Configuration hadoopConfiguration) {
+        return new RowDataFormatBuilder(rowType, hadoopConfiguration);
     }
 }

--- a/flink/src/main/java/io/delta/flink/source/internal/builder/RowDataFormatBuilder.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/builder/RowDataFormatBuilder.java
@@ -2,12 +2,9 @@ package io.delta.flink.source.internal.builder;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Stream;
 
 import io.delta.flink.source.internal.exceptions.DeltaSourceValidationException;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -40,15 +37,7 @@ public class RowDataFormatBuilder implements FormatBuilder<RowData> {
     // TODO PR 9.1 get this from options.
     private static final int BATCH_SIZE = 2048;
 
-    /**
-     * An array with Delta table's column names that should be read.
-     */
-    private final String[] columnNames;
-
-    /**
-     * An array of {@link LogicalType} for column names tha should raed from Delta table.
-     */
-    private final LogicalType[] columnTypes;
+    private final RowType rowType;
 
     /**
      * An instance of Hadoop configuration used to read Parquet files.
@@ -60,10 +49,8 @@ public class RowDataFormatBuilder implements FormatBuilder<RowData> {
      */
     private List<String> partitionColumns;
 
-    RowDataFormatBuilder(String[] columnNames,
-        LogicalType[] columnTypes, Configuration hadoopConfiguration) {
-        this.columnNames = columnNames;
-        this.columnTypes = columnTypes;
+    RowDataFormatBuilder(RowType rowType, Configuration hadoopConfiguration) {
+        this.rowType = rowType;
         this.hadoopConfiguration = hadoopConfiguration;
         this.partitionColumns = Collections.emptyList();
     }
@@ -89,10 +76,9 @@ public class RowDataFormatBuilder implements FormatBuilder<RowData> {
      *                                        RowDataFormatBuilder}. For example null arguments.
      */
     public RowDataFormat build() {
-        validateFormat();
 
         if (partitionColumns.isEmpty()) {
-            return buildFormatWithoutPartitions(columnNames, columnTypes, hadoopConfiguration);
+            return buildFormatWithoutPartitions();
         } else {
             // TODO PR 8
             throw new UnsupportedOperationException("Partition support will be added later.");
@@ -102,73 +88,13 @@ public class RowDataFormatBuilder implements FormatBuilder<RowData> {
         }
     }
 
-    private void validateFormat() {
-        Validator validator = validateMandatoryOptions();
-        if (validator.containsMessages()) {
-            // RowDataFormatBuilder does not know Delta's table path,
-            // hence null argument in DeltaSourceValidationException
-            throw new DeltaSourceValidationException(null, validator.getValidationMessages());
-        }
-    }
-
-    private RowDataFormat buildFormatWithoutPartitions(
-        String[] columnNames,
-        LogicalType[] columnTypes,
-        Configuration configuration) {
+    private RowDataFormat buildFormatWithoutPartitions() {
 
         return new RowDataFormat(
-            configuration,
-            RowType.of(columnTypes, columnNames),
+            hadoopConfiguration,
+            rowType,
             BATCH_SIZE,
             PARQUET_UTC_TIMESTAMP,
             PARQUET_CASE_SENSITIVE);
-    }
-
-    /**
-     * Validates a mandatory options for {@link RowDataFormatBuilder} such as
-     * <ul>
-     *     <li>null check on arguments</li>
-     *     <li>null values in arrays</li>
-     *     <li>size mismatch for column name and type arrays.</li>
-     * </ul>
-     *
-     * @return {@link Validator} instance containing validation error messages if any.
-     */
-    private Validator validateMandatoryOptions() {
-
-        Validator validator = new Validator()
-            // validate against null references
-            .checkNotNull(columnNames, EXCEPTION_PREFIX + "missing Delta table column names.")
-            .checkNotNull(columnTypes, EXCEPTION_PREFIX + "missing Delta table column types.")
-            .checkNotNull(hadoopConfiguration, EXCEPTION_PREFIX + "missing Hadoop configuration.");
-
-        if (columnNames != null) {
-            validator
-                .checkArgument(columnNames.length > 0,
-                    EXCEPTION_PREFIX + "empty array with column names.")
-                // validate invalid array element
-                .checkArgument(Stream.of(columnNames)
-                        .noneMatch(StringUtils::isNullOrWhitespaceOnly),
-                    EXCEPTION_PREFIX
-                        + "Column names array contains at least one element that is null, "
-                        + "empty, or contains only whitespace characters.");
-        }
-
-        if (columnTypes != null) {
-            validator
-                .checkArgument(columnTypes.length > 0,
-                    EXCEPTION_PREFIX + "empty array with column names.")
-                .checkArgument(Stream.of(columnTypes)
-                    .noneMatch(Objects::isNull), EXCEPTION_PREFIX + "Column type array contains at "
-                    + "least one null element.");
-        }
-
-        if (columnNames != null && columnTypes != null) {
-            validator
-                .checkArgument(columnNames.length == columnTypes.length,
-                    EXCEPTION_PREFIX + "column names and column types size does not match.");
-        }
-
-        return validator;
     }
 }

--- a/flink/src/main/java/io/delta/flink/source/internal/enumerator/BoundedSplitEnumeratorProvider.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/enumerator/BoundedSplitEnumeratorProvider.java
@@ -37,26 +37,26 @@ public class BoundedSplitEnumeratorProvider implements SplitEnumeratorProvider {
      *                               methods.
      */
     public BoundedSplitEnumeratorProvider(
-        FileSplitAssigner.Provider splitAssignerProvider,
-        AddFileEnumerator.Provider<DeltaSourceSplit> fileEnumeratorProvider) {
+            FileSplitAssigner.Provider splitAssignerProvider,
+            AddFileEnumerator.Provider<DeltaSourceSplit> fileEnumeratorProvider) {
         this.splitAssignerProvider = splitAssignerProvider;
         this.fileEnumeratorProvider = fileEnumeratorProvider;
     }
 
     @Override
     public BoundedDeltaSourceSplitEnumerator createInitialStateEnumerator(
-        Path deltaTablePath, Configuration configuration,
-        SplitEnumeratorContext<DeltaSourceSplit> enumContext,
-        DeltaSourceConfiguration sourceConfiguration) {
+            Path deltaTablePath, Configuration configuration,
+            SplitEnumeratorContext<DeltaSourceSplit> enumContext,
+            DeltaSourceConfiguration sourceConfiguration) {
 
         DeltaLog deltaLog =
             DeltaLog.forTable(configuration, SourceUtils.pathToString(deltaTablePath));
 
         BoundedSourceSnapshotSupplier snapshotSupplier =
-            new BoundedSourceSnapshotSupplier(deltaLog, sourceConfiguration);
+            new BoundedSourceSnapshotSupplier(deltaLog);
 
         SnapshotProcessor snapshotProcessor =
-            new SnapshotProcessor(deltaTablePath, snapshotSupplier.getSnapshot(),
+            new SnapshotProcessor(deltaTablePath, snapshotSupplier.getSnapshot(sourceConfiguration),
                 fileEnumeratorProvider.create(), Collections.emptySet());
 
         return new BoundedDeltaSourceSplitEnumerator(
@@ -66,9 +66,10 @@ public class BoundedSplitEnumeratorProvider implements SplitEnumeratorProvider {
 
     @Override
     public BoundedDeltaSourceSplitEnumerator createEnumeratorForCheckpoint(
-        DeltaEnumeratorStateCheckpoint<DeltaSourceSplit> checkpoint, Configuration configuration,
-        SplitEnumeratorContext<DeltaSourceSplit> enumContext,
-        DeltaSourceConfiguration sourceConfiguration) {
+            DeltaEnumeratorStateCheckpoint<DeltaSourceSplit> checkpoint,
+            Configuration configuration,
+            SplitEnumeratorContext<DeltaSourceSplit> enumContext,
+            DeltaSourceConfiguration sourceConfiguration) {
 
         DeltaLog deltaLog = DeltaLog.forTable(configuration,
             SourceUtils.pathToString(checkpoint.getDeltaTablePath()));

--- a/flink/src/main/java/io/delta/flink/source/internal/enumerator/ContinuousSplitEnumeratorProvider.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/enumerator/ContinuousSplitEnumeratorProvider.java
@@ -64,7 +64,7 @@ public class ContinuousSplitEnumeratorProvider implements SplitEnumeratorProvide
             DeltaLog.forTable(configuration, SourceUtils.pathToString(deltaTablePath));
 
         Snapshot snapshot =
-            new ContinuousSourceSnapshotSupplier(deltaLog, sourceConfiguration).getSnapshot();
+            new ContinuousSourceSnapshotSupplier(deltaLog).getSnapshot(sourceConfiguration);
 
         ContinuousTableProcessor tableProcessor =
             createTableProcessor(

--- a/flink/src/main/java/io/delta/flink/source/internal/enumerator/supplier/BoundedSnapshotSupplierFactory.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/enumerator/supplier/BoundedSnapshotSupplierFactory.java
@@ -1,0 +1,11 @@
+package io.delta.flink.source.internal.enumerator.supplier;
+
+import io.delta.standalone.DeltaLog;
+
+public class BoundedSnapshotSupplierFactory implements SnapshotSupplierFactory {
+
+    @Override
+    public BoundedSourceSnapshotSupplier create(DeltaLog deltaLog) {
+        return new BoundedSourceSnapshotSupplier(deltaLog);
+    }
+}

--- a/flink/src/main/java/io/delta/flink/source/internal/enumerator/supplier/ContinuousSnapshotSupplierFactory.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/enumerator/supplier/ContinuousSnapshotSupplierFactory.java
@@ -1,0 +1,11 @@
+package io.delta.flink.source.internal.enumerator.supplier;
+
+import io.delta.standalone.DeltaLog;
+
+public class ContinuousSnapshotSupplierFactory implements SnapshotSupplierFactory {
+
+    @Override
+    public ContinuousSourceSnapshotSupplier create(DeltaLog deltaLog) {
+        return new ContinuousSourceSnapshotSupplier(deltaLog);
+    }
+}

--- a/flink/src/main/java/io/delta/flink/source/internal/enumerator/supplier/ContinuousSourceSnapshotSupplier.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/enumerator/supplier/ContinuousSourceSnapshotSupplier.java
@@ -16,9 +16,8 @@ import io.delta.standalone.Snapshot;
  */
 public class ContinuousSourceSnapshotSupplier extends SnapshotSupplier {
 
-    public ContinuousSourceSnapshotSupplier(DeltaLog deltaLog,
-        DeltaSourceConfiguration sourceConfiguration) {
-        super(deltaLog, sourceConfiguration);
+    public ContinuousSourceSnapshotSupplier(DeltaLog deltaLog) {
+        super(deltaLog);
     }
 
     /**
@@ -37,15 +36,16 @@ public class ContinuousSourceSnapshotSupplier extends SnapshotSupplier {
      * snapshot was found.
      */
     @Override
-    public Snapshot getSnapshot() {
-        return getSnapshotFromStartingVersionOption()
-            .or(this::getSnapshotFromStartingTimestampOption)
+    public Snapshot getSnapshot(DeltaSourceConfiguration sourceConfiguration) {
+        return getSnapshotFromStartingVersionOption(sourceConfiguration)
+            .or(() -> getSnapshotFromStartingTimestampOption(sourceConfiguration))
             .or(this::getHeadSnapshot)
             .get();
     }
 
-    private TransitiveOptional<Snapshot> getSnapshotFromStartingVersionOption() {
-        String startingVersion = getOptionValue(STARTING_VERSION);
+    private TransitiveOptional<Snapshot> getSnapshotFromStartingVersionOption(
+            DeltaSourceConfiguration sourceConfiguration) {
+        String startingVersion = sourceConfiguration.getValue(STARTING_VERSION);
         if (startingVersion != null) {
             if (startingVersion.equalsIgnoreCase(DeltaSourceOptions.STARTING_VERSION_LATEST)) {
                 return TransitiveOptional.ofNullable(deltaLog.snapshot());
@@ -59,8 +59,9 @@ public class ContinuousSourceSnapshotSupplier extends SnapshotSupplier {
         return TransitiveOptional.empty();
     }
 
-    private TransitiveOptional<Snapshot> getSnapshotFromStartingTimestampOption() {
-        String startingTimestamp = getOptionValue(STARTING_TIMESTAMP);
+    private TransitiveOptional<Snapshot> getSnapshotFromStartingTimestampOption(
+            DeltaSourceConfiguration sourceConfiguration) {
+        String startingTimestamp = sourceConfiguration.getValue(STARTING_TIMESTAMP);
         if (startingTimestamp != null) {
             return TransitiveOptional.ofNullable(deltaLog.getSnapshotForTimestampAsOf(
                 TimestampFormatConverter.convertToTimestamp(startingTimestamp)));

--- a/flink/src/main/java/io/delta/flink/source/internal/enumerator/supplier/SnapshotSupplier.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/enumerator/supplier/SnapshotSupplier.java
@@ -2,7 +2,6 @@ package io.delta.flink.source.internal.enumerator.supplier;
 
 import io.delta.flink.source.internal.DeltaSourceConfiguration;
 import io.delta.flink.source.internal.utils.TransitiveOptional;
-import org.apache.flink.configuration.ConfigOption;
 
 import io.delta.standalone.DeltaLog;
 import io.delta.standalone.Snapshot;
@@ -18,24 +17,15 @@ public abstract class SnapshotSupplier {
      */
     protected final DeltaLog deltaLog;
 
-    /**
-     * The {@link DeltaSourceConfiguration} with used
-     * {@link io.delta.flink.source.internal.DeltaSourceOptions}.
-     */
-    protected final DeltaSourceConfiguration sourceConfiguration;
-
-    protected SnapshotSupplier(
-        DeltaLog deltaLog,
-        DeltaSourceConfiguration sourceConfiguration) {
+    protected SnapshotSupplier(DeltaLog deltaLog) {
         this.deltaLog = deltaLog;
-        this.sourceConfiguration = sourceConfiguration;
     }
 
     /**
      * @return A {@link Snapshot} instance acquired from {@link #deltaLog}. Every implementation of
      * {@link SnapshotSupplier} class can have its own rules about how snapshot should be acquired.
      */
-    public abstract Snapshot getSnapshot();
+    public abstract Snapshot getSnapshot(DeltaSourceConfiguration sourceConfiguration);
 
     /**
      * A helper method that returns the latest {@link Snapshot} at moment when this method was
@@ -47,13 +37,5 @@ public abstract class SnapshotSupplier {
      */
     protected TransitiveOptional<Snapshot> getHeadSnapshot() {
         return TransitiveOptional.ofNullable(deltaLog.snapshot());
-    }
-
-    /**
-     * A helper method to get the value of {@link io.delta.flink.source.internal.DeltaSourceOptions}
-     * from {@link #sourceConfiguration}.
-     */
-    protected <T> T getOptionValue(ConfigOption<T> option) {
-        return this.sourceConfiguration.getValue(option);
     }
 }

--- a/flink/src/main/java/io/delta/flink/source/internal/enumerator/supplier/SnapshotSupplierFactory.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/enumerator/supplier/SnapshotSupplierFactory.java
@@ -1,0 +1,8 @@
+package io.delta.flink.source.internal.enumerator.supplier;
+
+import io.delta.standalone.DeltaLog;
+
+public interface SnapshotSupplierFactory {
+
+    SnapshotSupplier create(DeltaLog deltaLog);
+}

--- a/flink/src/main/java/io/delta/flink/source/internal/utils/SourceSchema.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/utils/SourceSchema.java
@@ -1,0 +1,23 @@
+package io.delta.flink.source.internal.utils;
+
+import org.apache.flink.table.types.logical.LogicalType;
+
+public class SourceSchema {
+
+    private final String[] columnNames;
+
+    private final LogicalType[] columnTypes;
+
+    public SourceSchema(String[] columnNames, LogicalType[] columnTypes) {
+        this.columnNames = columnNames;
+        this.columnTypes = columnTypes;
+    }
+
+    public String[] getColumnNames() {
+        return columnNames;
+    }
+
+    public LogicalType[] getColumnTypes() {
+        return columnTypes;
+    }
+}

--- a/flink/src/main/java/io/delta/flink/source/internal/utils/SourceUtils.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/utils/SourceUtils.java
@@ -1,10 +1,15 @@
 package io.delta.flink.source.internal.utils;
 
+import java.util.Collection;
+
+import io.delta.flink.source.internal.SchemaConverter;
 import org.apache.flink.core.fs.Path;
-import org.apache.hadoop.conf.Configuration;
+import org.apache.flink.table.types.logical.LogicalType;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
-import io.delta.standalone.DeltaLog;
+import io.delta.standalone.types.DataType;
+import io.delta.standalone.types.StructField;
+import io.delta.standalone.types.StructType;
 
 /**
  * A utility class for Source connector
@@ -26,7 +31,32 @@ public final class SourceUtils {
         return path.toUri().normalize().toString();
     }
 
-    public static DeltaLog createDeltaLog(Path deltaTablePath, Configuration hadoopConfiguration) {
-        return DeltaLog.forTable(hadoopConfiguration, SourceUtils.pathToString(deltaTablePath));
+    public static SourceSchema buildSourceSchema(
+            Collection<String> userColumnNames,
+            StructType logSchema) {
+        String[] columnNames;
+        LogicalType[] columnTypes;
+        if (userColumnNames != null && !userColumnNames.isEmpty()) {
+            columnTypes = new LogicalType[userColumnNames.size()];
+            int i = 0;
+            for (String columnName : userColumnNames) {
+                DataType dataType = logSchema.get(columnName).getDataType();
+                columnTypes[i++] = SchemaConverter.toFlinkDataType(dataType);
+            }
+            columnNames = userColumnNames.toArray(new String[0]);
+        } else {
+            StructField[] fields = logSchema.getFields();
+            columnNames = new String[fields.length];
+            columnTypes = new LogicalType[fields.length];
+            int i = 0;
+            for (StructField field : fields) {
+                columnNames[i] = field.getName();
+                columnTypes[i] = SchemaConverter.toFlinkDataType(field.getDataType());
+                i++;
+            }
+        }
+
+        return new SourceSchema(columnNames, columnTypes);
     }
+
 }

--- a/flink/src/test/java/io/delta/flink/source/DeltaSourceBoundedExecutionITCaseTest.java
+++ b/flink/src/test/java/io/delta/flink/source/DeltaSourceBoundedExecutionITCaseTest.java
@@ -11,7 +11,6 @@ import io.delta.flink.DeltaTestUtils;
 import io.delta.flink.source.RecordCounterToFail.FailCheck;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.After;
 import org.junit.Before;
@@ -55,40 +54,61 @@ public class DeltaSourceBoundedExecutionITCaseTest extends DeltaSourceITBase {
     // meaning if splits were added back to the Enumerator's state and reassigned to new TM.
     public void shouldReadDeltaTable() throws Exception {
 
-        DeltaSource<RowData> deltaSource =
-            initBoundedSource(
-                nonPartitionedLargeTablePath,
-                LARGE_TABLE_COLUMN_NAMES,
-                LARGE_TABLE_COLUMN_TYPES);
+        List<DeltaSource<RowData>> deltaSources = Arrays.asList(
+            initBoundedSource(nonPartitionedLargeTablePath),
+            initBoundedSource(nonPartitionedLargeTablePath, LARGE_TABLE_COLUMN_NAMES)
+        );
 
-        // WHEN
-        // Fail TaskManager or JobManager after half of the records or do not fail anything if
-        // FailoverType.NONE.
-        List<RowData> resultData = testBoundDeltaSource(failoverType, deltaSource,
-            (FailCheck) readRows -> readRows == LARGE_TABLE_RECORD_COUNT / 2);
+        for (DeltaSource<RowData> deltaSource : deltaSources) {
+            System.out.println("Starting test");
+            // WHEN
+            // Fail TaskManager or JobManager after half of the records or do not fail anything if
+            // FailoverType.NONE.
+            List<RowData> resultData = testBoundDeltaSource(failoverType, deltaSource,
+                (FailCheck) readRows -> readRows == LARGE_TABLE_RECORD_COUNT / 2);
 
-        Set<Long> actualValues =
-            resultData.stream().map(row -> row.getLong(0)).collect(Collectors.toSet());
+            Set<Long> actualValues =
+                resultData.stream().map(row -> row.getLong(0)).collect(Collectors.toSet());
 
-        // THEN
-        assertThat("Source read different number of rows that Delta table have.", resultData.size(),
-            equalTo(LARGE_TABLE_RECORD_COUNT));
-        assertThat("Source Must Have produced some duplicates.", actualValues.size(),
-            equalTo(LARGE_TABLE_RECORD_COUNT));
+            // THEN
+            assertThat("Source read different number of rows that Delta table have.",
+                resultData.size(),
+                equalTo(LARGE_TABLE_RECORD_COUNT));
+            assertThat("Source Must Have produced some duplicates.", actualValues.size(),
+                equalTo(LARGE_TABLE_RECORD_COUNT));
+        }
     }
 
     // TODO PR 8 ADD Partition tests in later PRs
 
-    private DeltaSource<RowData> initBoundedSource(
-        String tablePath, String[] columnNames, LogicalType[] columnTypes) {
+    /**
+     * Initialize a Delta source in bounded mode that should take entire Delta table schema
+     * from Delta's metadata.
+     */
+    private DeltaSource<RowData> initBoundedSource(String tablePath) {
 
         Configuration hadoopConf = DeltaTestUtils.getHadoopConf();
 
         return DeltaSource.forBoundedRowData(
-            Path.fromLocalFile(new File(tablePath)),
-            columnNames,
-            columnTypes,
-            hadoopConf
-        ).build();
+                Path.fromLocalFile(new File(tablePath)),
+                hadoopConf
+            )
+            .build();
+    }
+
+    /**
+     * Initialize a Delta source in bounded mode that should take only user defined columns
+     * from Delta's metadata.
+     */
+    private DeltaSource<RowData> initBoundedSource(String tablePath, String[] columnNames) {
+
+        Configuration hadoopConf = DeltaTestUtils.getHadoopConf();
+
+        return DeltaSource.forBoundedRowData(
+                Path.fromLocalFile(new File(tablePath)),
+                hadoopConf
+            )
+            .columnNames(Arrays.asList(columnNames))
+            .build();
     }
 }

--- a/flink/src/test/java/io/delta/flink/source/DeltaSourceContinuousExecutionITCaseTest.java
+++ b/flink/src/test/java/io/delta/flink/source/DeltaSourceContinuousExecutionITCaseTest.java
@@ -12,7 +12,6 @@ import io.delta.flink.DeltaTestUtils;
 import io.delta.flink.source.RecordCounterToFail.FailCheck;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
 import org.apache.hadoop.conf.Configuration;
@@ -74,11 +73,7 @@ public class DeltaSourceContinuousExecutionITCaseTest extends DeltaSourceITBase 
 
         // GIVEN
         DeltaSource<RowData> deltaSource =
-            initContinuousSource(
-                nonPartitionedTablePath,
-                SMALL_TABLE_COLUMN_NAMES,
-                SMALL_TABLE_COLUMN_TYPES
-            );
+            initContinuousSource(nonPartitionedTablePath, SMALL_TABLE_COLUMN_NAMES);
 
         // WHEN
         // Fail TaskManager or JobManager after half of the records or do not fail anything if
@@ -110,11 +105,7 @@ public class DeltaSourceContinuousExecutionITCaseTest extends DeltaSourceITBase 
 
         // GIVEN
         DeltaSource<RowData> deltaSource =
-            initContinuousSource(
-                nonPartitionedLargeTablePath,
-                LARGE_TABLE_COLUMN_NAMES,
-                LARGE_TABLE_COLUMN_TYPES
-            );
+            initContinuousSource(nonPartitionedLargeTablePath, LARGE_TABLE_COLUMN_NAMES);
 
         // WHEN
         List<List<RowData>> resultData = testContinuousDeltaSource(failoverType, deltaSource,
@@ -143,37 +134,42 @@ public class DeltaSourceContinuousExecutionITCaseTest extends DeltaSourceITBase 
     public void shouldReadDeltaTableFromSnapshotAndUpdates() throws Exception {
 
         // GIVEN
-        DeltaSource<RowData> deltaSource =
-            initContinuousSource(
-                nonPartitionedTablePath,
-                SMALL_TABLE_COLUMN_NAMES,
-                SMALL_TABLE_COLUMN_TYPES
-            );
+        List<DeltaSource<RowData>> deltaSources = Arrays.asList(
+            initContinuousSource(nonPartitionedTablePath),
+            initContinuousSource(nonPartitionedTablePath, SMALL_TABLE_COLUMN_NAMES)
+        );
 
-        ContinuousTestDescriptor testDescriptor = prepareTableUpdates();
+        for (DeltaSource<RowData> deltaSource : deltaSources) {
+            System.out.println("Starting test");
+            ContinuousTestDescriptor testDescriptor = prepareTableUpdates();
 
-        // WHEN
-        List<List<RowData>> resultData =
-            testContinuousDeltaSource(failoverType, deltaSource, testDescriptor,
-                (FailCheck) readRows -> readRows
-                    == (INITIAL_DATA_SIZE + NUMBER_OF_TABLE_UPDATE_BULKS * ROWS_PER_TABLE_UPDATE)
-                    / 2);
+            // WHEN
+            List<List<RowData>> resultData =
+                testContinuousDeltaSource(failoverType, deltaSource, testDescriptor,
+                    (FailCheck) readRows -> readRows
+                        ==
+                        (INITIAL_DATA_SIZE + NUMBER_OF_TABLE_UPDATE_BULKS * ROWS_PER_TABLE_UPDATE)
+                            / 2);
 
-        int totalNumberOfRows = resultData.stream().mapToInt(List::size).sum();
+            int totalNumberOfRows = resultData.stream().mapToInt(List::size).sum();
 
-        // Each row has a unique column across all Delta table data. We are converting List or
-        // read rows to set of values for that unique column.
-        // If there were eny duplicates or missing values we will catch them here by comparing
-        // size of that Set to expected number of rows.
-        Set<String> uniqueValues =
-            resultData.stream().flatMap(Collection::stream).map(row -> row.getString(1).toString())
-                .collect(Collectors.toSet());
+            // Each row has a unique column across all Delta table data. We are converting List or
+            // read rows to set of values for that unique column.
+            // If there were eny duplicates or missing values we will catch them here by comparing
+            // size of that Set to expected number of rows.
+            Set<String> uniqueValues =
+                resultData.stream().flatMap(Collection::stream)
+                    .map(row -> row.getString(1).toString())
+                    .collect(Collectors.toSet());
 
-        // THEN
-        assertThat("Source read different number of rows that Delta Table have.", totalNumberOfRows,
-            equalTo(INITIAL_DATA_SIZE + NUMBER_OF_TABLE_UPDATE_BULKS * ROWS_PER_TABLE_UPDATE));
-        assertThat("Source Produced Different Rows that were in Delta Table", uniqueValues.size(),
-            equalTo(INITIAL_DATA_SIZE + NUMBER_OF_TABLE_UPDATE_BULKS * ROWS_PER_TABLE_UPDATE));
+            // THEN
+            assertThat("Source read different number of rows that Delta Table have.",
+                totalNumberOfRows,
+                equalTo(INITIAL_DATA_SIZE + NUMBER_OF_TABLE_UPDATE_BULKS * ROWS_PER_TABLE_UPDATE));
+            assertThat("Source Produced Different Rows that were in Delta Table",
+                uniqueValues.size(),
+                equalTo(INITIAL_DATA_SIZE + NUMBER_OF_TABLE_UPDATE_BULKS * ROWS_PER_TABLE_UPDATE));
+        }
     }
 
     /**
@@ -196,16 +192,34 @@ public class DeltaSourceContinuousExecutionITCaseTest extends DeltaSourceITBase 
 
     // TODO PR 8 Add tests for Partitions
 
-    private DeltaSource<RowData> initContinuousSource(
-        String tablePath, String[] columnNames, LogicalType[] columnTypes) {
+    /**
+     * Initialize a Delta source in continuous mode that should take entire Delta table schema
+     * from Delta's metadata.
+     */
+    private DeltaSource<RowData> initContinuousSource(String tablePath) {
 
         Configuration hadoopConf = DeltaTestUtils.getHadoopConf();
 
         return DeltaSource.forContinuousRowData(
-            Path.fromLocalFile(new File(tablePath)),
-            columnNames,
-            columnTypes,
-            hadoopConf
-        ).build();
+                Path.fromLocalFile(new File(tablePath)),
+                hadoopConf
+            )
+            .build();
+    }
+
+    /**
+     * Initialize a Delta source in continuous mode that should take only user defined columns
+     * from Delta's metadata.
+     */
+    private DeltaSource<RowData> initContinuousSource(String tablePath, String[] columnNames) {
+
+        Configuration hadoopConf = DeltaTestUtils.getHadoopConf();
+
+        return DeltaSource.forContinuousRowData(
+                Path.fromLocalFile(new File(tablePath)),
+                hadoopConf
+            )
+            .columnNames(Arrays.asList(columnNames))
+            .build();
     }
 }

--- a/flink/src/test/java/io/delta/flink/source/DeltaSourceITBase.java
+++ b/flink/src/test/java/io/delta/flink/source/DeltaSourceITBase.java
@@ -29,7 +29,6 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.collect.ClientAndIterator;
-import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -55,9 +54,6 @@ public abstract class DeltaSourceITBase extends TestLogger {
     protected static final int SMALL_TABLE_COUNT = 2;
 
     protected static final String[] LARGE_TABLE_COLUMN_NAMES = {"col1", "col2", "col3"};
-
-    protected static final LogicalType[] LARGE_TABLE_COLUMN_TYPES =
-        {new BigIntType(), new BigIntType(), new CharType()};
 
     protected static final int LARGE_TABLE_RECORD_COUNT = 1100;
 

--- a/flink/src/test/java/io/delta/flink/source/RowDataBoundedDeltaSourceBuilderTest.java
+++ b/flink/src/test/java/io/delta/flink/source/RowDataBoundedDeltaSourceBuilderTest.java
@@ -1,17 +1,31 @@
 package io.delta.flink.source;
 
+import java.util.Arrays;
+
 import io.delta.flink.sink.utils.DeltaSinkTestUtils;
 import io.delta.flink.source.internal.DeltaSourceOptions;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.LogicalType;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
 
+import io.delta.standalone.types.StringType;
+import io.delta.standalone.types.StructField;
+
+@ExtendWith(MockitoExtension.class)
 class RowDataBoundedDeltaSourceBuilderTest extends RowDataDeltaSourceBuilderTestBase {
+
+    @AfterEach
+    public void afterEach() {
+        closeDeltaLogStatic();
+    }
 
     ////////////////////////////////
     // Continuous-only test cases //
@@ -19,10 +33,14 @@ class RowDataBoundedDeltaSourceBuilderTest extends RowDataDeltaSourceBuilderTest
 
     @Test
     public void shouldCreateSource() {
+
+        when(deltaLog.snapshot()).thenReturn(headSnapshot);
+
+        StructField[] schema = {new StructField("col1", new StringType())};
+        mockDeltaTableForSchema(schema);
+
         DeltaSource<RowData> boundedSource = DeltaSource.forBoundedRowData(
                 new Path(TABLE_PATH),
-                COLUMN_NAMES,
-                COLUMN_TYPES,
                 DeltaSinkTestUtils.getHadoopConf())
             .build();
 
@@ -32,18 +50,21 @@ class RowDataBoundedDeltaSourceBuilderTest extends RowDataDeltaSourceBuilderTest
 
     @Test
     public void shouldCreateSourceWithOptions() {
+        when(deltaLog.getSnapshotForVersionAsOf(10L)).thenReturn(headSnapshot);
+
+        StructField[] schema = {new StructField("col1", new StringType())};
+        mockDeltaTableForSchema(schema);
+
         DeltaSource<RowData> boundedSource = DeltaSource.forBoundedRowData(
                 new Path(TABLE_PATH),
-                COLUMN_NAMES,
-                COLUMN_TYPES,
                 DeltaSinkTestUtils.getHadoopConf())
-            .option(DeltaSourceOptions.VERSION_AS_OF.key(), 10)
+            .option(DeltaSourceOptions.VERSION_AS_OF.key(), 10L)
             .build();
 
         assertThat(boundedSource, notNullValue());
         assertThat(boundedSource.getBoundedness(), equalTo(Boundedness.BOUNDED));
         assertThat(boundedSource.getSourceConfiguration()
-            .getValue(DeltaSourceOptions.VERSION_AS_OF), equalTo(10));
+            .getValue(DeltaSourceOptions.VERSION_AS_OF), equalTo(10L));
     }
 
     //////////////////////////////////////////////////////////////
@@ -54,30 +75,23 @@ class RowDataBoundedDeltaSourceBuilderTest extends RowDataDeltaSourceBuilderTest
     protected RowDataBoundedDeltaSourceBuilder getBuilderWithNulls() {
         return DeltaSource.forBoundedRowData(
             null,
-            null,
-            null,
             null
         );
     }
 
     @Override
-    protected RowDataBoundedDeltaSourceBuilder getBuilderForColumns(
-        String[] columnNames,
-        LogicalType[] columnTypes) {
+    protected RowDataBoundedDeltaSourceBuilder getBuilderForColumns(String[] columnNames) {
         return DeltaSource.forBoundedRowData(
-            new Path(TABLE_PATH),
-            columnNames,
-            columnTypes,
-            DeltaSinkTestUtils.getHadoopConf()
-        );
+                new Path(TABLE_PATH),
+                DeltaSinkTestUtils.getHadoopConf()
+            )
+            .columnNames((columnNames != null) ? Arrays.asList(columnNames) : null);
     }
 
     @Override
     protected RowDataBoundedDeltaSourceBuilder getBuilderWithMutuallyExcludedOptions() {
         return DeltaSource.forBoundedRowData(
                 new Path(TABLE_PATH),
-                COLUMN_NAMES,
-                COLUMN_TYPES,
                 DeltaSinkTestUtils.getHadoopConf()
             )
             .versionAsOf(10)
@@ -88,8 +102,6 @@ class RowDataBoundedDeltaSourceBuilderTest extends RowDataDeltaSourceBuilderTest
     protected RowDataBoundedDeltaSourceBuilder getBuilderWithGenericMutuallyExcludedOptions() {
         return DeltaSource.forBoundedRowData(
                 new Path(TABLE_PATH),
-                COLUMN_NAMES,
-                COLUMN_TYPES,
                 DeltaSinkTestUtils.getHadoopConf()
             )
             .option(DeltaSourceOptions.VERSION_AS_OF.key(), 10)
@@ -100,8 +112,6 @@ class RowDataBoundedDeltaSourceBuilderTest extends RowDataDeltaSourceBuilderTest
     protected RowDataBoundedDeltaSourceBuilder
         getBuilderWithNullMandatoryFieldsAndExcludedOption() {
         return DeltaSource.forBoundedRowData(
-                null,
-                null,
                 null,
                 DeltaSinkTestUtils.getHadoopConf()
             )

--- a/flink/src/test/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilderTest.java
+++ b/flink/src/test/java/io/delta/flink/source/RowDataContinuousDeltaSourceBuilderTest.java
@@ -1,17 +1,31 @@
 package io.delta.flink.source;
 
+import java.util.Arrays;
+
 import io.delta.flink.sink.utils.DeltaSinkTestUtils;
 import io.delta.flink.source.internal.DeltaSourceOptions;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.LogicalType;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
 
+import io.delta.standalone.types.StringType;
+import io.delta.standalone.types.StructField;
+
+@ExtendWith(MockitoExtension.class)
 class RowDataContinuousDeltaSourceBuilderTest extends RowDataDeltaSourceBuilderTestBase {
+
+    @AfterEach
+    public void afterEach() {
+        closeDeltaLogStatic();
+    }
 
     ////////////////////////////////
     // Continuous-only test cases //
@@ -19,10 +33,13 @@ class RowDataContinuousDeltaSourceBuilderTest extends RowDataDeltaSourceBuilderT
 
     @Test
     public void shouldCreateSource() {
+        when(deltaLog.snapshot()).thenReturn(headSnapshot);
+
+        StructField[] schema = {new StructField("col1", new StringType())};
+        mockDeltaTableForSchema(schema);
+
         DeltaSource<RowData> boundedSource = DeltaSource.forContinuousRowData(
                 new Path(TABLE_PATH),
-                COLUMN_NAMES,
-                COLUMN_TYPES,
                 DeltaSinkTestUtils.getHadoopConf())
             .build();
 
@@ -32,18 +49,22 @@ class RowDataContinuousDeltaSourceBuilderTest extends RowDataDeltaSourceBuilderT
 
     @Test
     public void shouldCreateSourceWithOptions() {
+
+        when(deltaLog.getSnapshotForVersionAsOf(10)).thenReturn(headSnapshot);
+
+        StructField[] schema = {new StructField("col1", new StringType())};
+        mockDeltaTableForSchema(schema);
+
         DeltaSource<RowData> boundedSource = DeltaSource.forContinuousRowData(
                 new Path(TABLE_PATH),
-                COLUMN_NAMES,
-                COLUMN_TYPES,
                 DeltaSinkTestUtils.getHadoopConf())
-            .option(DeltaSourceOptions.STARTING_TIMESTAMP.key(), 10)
+            .option(DeltaSourceOptions.STARTING_VERSION.key(), "10")
             .build();
 
         assertThat(boundedSource, notNullValue());
         assertThat(boundedSource.getBoundedness(), equalTo(Boundedness.CONTINUOUS_UNBOUNDED));
         assertThat(boundedSource.getSourceConfiguration()
-            .getValue(DeltaSourceOptions.STARTING_TIMESTAMP), equalTo(10));
+            .getValue(DeltaSourceOptions.STARTING_VERSION), equalTo("10"));
     }
 
     //////////////////////////////////////////////////////////////
@@ -54,30 +75,23 @@ class RowDataContinuousDeltaSourceBuilderTest extends RowDataDeltaSourceBuilderT
     protected RowDataContinuousDeltaSourceBuilder getBuilderWithNulls() {
         return DeltaSource.forContinuousRowData(
             null,
-            null,
-            null,
             null
         );
     }
 
     @Override
-    protected RowDataContinuousDeltaSourceBuilder getBuilderForColumns(
-        String[] columnNames,
-        LogicalType[] columnTypes) {
+    protected RowDataContinuousDeltaSourceBuilder getBuilderForColumns(String[] columnNames) {
         return DeltaSource.forContinuousRowData(
-            new Path(TABLE_PATH),
-            columnNames,
-            columnTypes,
-            DeltaSinkTestUtils.getHadoopConf()
-        );
+                new Path(TABLE_PATH),
+                DeltaSinkTestUtils.getHadoopConf()
+            )
+            .columnNames((columnNames != null) ? Arrays.asList(columnNames) : null);
     }
 
     @Override
     protected RowDataContinuousDeltaSourceBuilder getBuilderWithMutuallyExcludedOptions() {
         return DeltaSource.forContinuousRowData(
                 new Path(TABLE_PATH),
-                COLUMN_NAMES,
-                COLUMN_TYPES,
                 DeltaSinkTestUtils.getHadoopConf()
             )
             .startingVersion(10)
@@ -88,8 +102,6 @@ class RowDataContinuousDeltaSourceBuilderTest extends RowDataDeltaSourceBuilderT
     protected RowDataContinuousDeltaSourceBuilder getBuilderWithGenericMutuallyExcludedOptions() {
         return DeltaSource.forContinuousRowData(
                 new Path(TABLE_PATH),
-                COLUMN_NAMES,
-                COLUMN_TYPES,
                 DeltaSinkTestUtils.getHadoopConf()
             )
             .option(DeltaSourceOptions.STARTING_VERSION.key(), 10)
@@ -100,8 +112,6 @@ class RowDataContinuousDeltaSourceBuilderTest extends RowDataDeltaSourceBuilderT
     protected RowDataContinuousDeltaSourceBuilder
         getBuilderWithNullMandatoryFieldsAndExcludedOption() {
         return DeltaSource.forContinuousRowData(
-                null,
-                null,
                 null,
                 DeltaSinkTestUtils.getHadoopConf()
             )

--- a/flink/src/test/java/io/delta/flink/source/RowDataDeltaSourceBuilderTestBase.java
+++ b/flink/src/test/java/io/delta/flink/source/RowDataDeltaSourceBuilderTestBase.java
@@ -5,30 +5,52 @@ import java.util.stream.Stream;
 
 import io.delta.flink.source.internal.builder.DeltaSourceBuilderBase;
 import io.delta.flink.source.internal.exceptions.DeltaSourceValidationException;
-import org.apache.flink.table.types.logical.CharType;
-import org.apache.flink.table.types.logical.IntType;
-import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.hadoop.conf.Configuration;
 import org.codehaus.janino.util.Producer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import io.delta.standalone.DeltaLog;
+import io.delta.standalone.Snapshot;
+import io.delta.standalone.actions.Metadata;
+import io.delta.standalone.types.StructField;
+import io.delta.standalone.types.StructType;
 
 public abstract class RowDataDeltaSourceBuilderTestBase {
 
     protected static final Logger LOG =
         LoggerFactory.getLogger(RowDataBoundedDeltaSourceBuilderTest.class);
 
-    protected static final String[] COLUMN_NAMES = {"name", "surname", "age"};
-
     protected static final String TABLE_PATH = "s3://some/path/";
 
-    protected static final LogicalType[] COLUMN_TYPES =
-        {new CharType(), new CharType(), new IntType()};
+    @Mock
+    protected DeltaLog deltaLog;
+
+    @Mock
+    protected Snapshot headSnapshot;
+
+    @Mock
+    protected Metadata metadata;
+
+    protected MockedStatic<DeltaLog> deltaLogStatic;
+
+    public void closeDeltaLogStatic() {
+        if (deltaLogStatic != null) {
+            deltaLogStatic.close();
+        }
+    }
 
     /**
      * @return A Stream of arguments for parametrized test such that every element contains:
@@ -42,63 +64,17 @@ public abstract class RowDataDeltaSourceBuilderTestBase {
      */
     protected static Stream<Arguments> columnArrays() {
         return Stream.of(
-            // Validation error due to different size of column names and column types array.
-            Arguments.of(
-                new String[]{"col1", "col2"},
-                new LogicalType[]{new CharType(), new CharType(), new CharType()},
-                1),
+            // Validation error due to blank column name.
+            Arguments.of(new String[]{"col1", " "}, 1),
 
-            // Validation error due to different size of column names and column types array.
-            Arguments.of(
-                new String[]{"col1", "col2", "col3"},
-                new LogicalType[]{new CharType(), new CharType()},
-                1),
+            // Validation error due to empty column name.
+            Arguments.of(new String[]{"col1", ""}, 1),
 
             // Validation error due to null element in column name array.
-            Arguments.of(
-                new String[]{"col1", null, "col3"},
-                new LogicalType[]{new CharType(), new CharType(), new CharType()},
-                1),
-
-            // Validation error due to null element in column type array.
-            Arguments.of(
-                new String[]{"col1", "col2", "col3"},
-                new LogicalType[]{new CharType(), null, new CharType()},
-                1),
-
-            // Expecting two validation errors due to null element in column name array and array
-            // length mismatch for column names and types.
-            Arguments.of(
-                new String[]{"col1", null, "col3"},
-                new LogicalType[]{new CharType(), new CharType()},
-                2),
-
-            // Expecting two validation errors due to null element in column type array and array
-            // length mismatch for column names and types.
-            Arguments.of(
-                new String[]{"col1", "col3"},
-                new LogicalType[]{new CharType(), null, new CharType()},
-                2),
-
-            // Expecting two validation errors due to null reference to column name array and
-            // null element in column type array.
-            Arguments.of(
-                null,
-                new LogicalType[]{new CharType(), null, new CharType()},
-                2),
+            Arguments.of(new String[]{"col1", null, "col3"}, 1),
 
             // Validation error due to null reference to column name array.
-            Arguments.of(
-                null,
-                new LogicalType[]{new CharType(), new CharType()},
-                1),
-
-            // Validation error due to null reference to column type array.
-            Arguments.of(new String[]{"col1", "col3"}, null, 1),
-
-            // Validation error due to null reference to column type array and null element in
-            // column name array.
-            Arguments.of(new String[]{"col1", null}, null, 2)
+            Arguments.of(null, 1)
         );
     }
 
@@ -106,19 +82,15 @@ public abstract class RowDataDeltaSourceBuilderTestBase {
      * Test for column name and colum type arrays.
      *
      * @param columnNames        An array with column names.
-     * @param columnTypes        An array with column types.
      * @param expectedErrorCount Number of expected validation errors for given combination of
      *                           column names and types.
      */
     @ParameterizedTest
     @MethodSource("columnArrays")
-    public void testColumnArrays(
-            String[] columnNames,
-            LogicalType[] columnTypes,
-            int expectedErrorCount) {
+    public void testColumnArrays(String[] columnNames, int expectedErrorCount) {
 
         Optional<Exception> validation = testValidation(
-            () -> getBuilderForColumns(columnNames, columnTypes).build()
+            () -> getBuilderForColumns(columnNames).build()
         );
 
         DeltaSourceValidationException exception =
@@ -139,8 +111,7 @@ public abstract class RowDataDeltaSourceBuilderTestBase {
             (DeltaSourceValidationException) validation.orElseThrow(
                 () -> new AssertionError("Builder should throw exception on null arguments."));
 
-        // expected number is 5 because Hadoop is used and validated by Format and Source builders.
-        assertThat(exception.getValidationMessages().size(), equalTo(5));
+        assertThat(exception.getValidationMessages().size(), equalTo(2));
     }
 
     @Test
@@ -184,16 +155,12 @@ public abstract class RowDataDeltaSourceBuilderTestBase {
             (DeltaSourceValidationException) validation.orElseThrow(
                 () -> new AssertionError("Builder should throw validation exception."));
 
-        // expected number is 5 because Hadoop is used and validated by Format and Source builders.
-        assertThat(exception.getValidationMessages().size(), equalTo(4));
+        assertThat(exception.getValidationMessages().size(), equalTo(2));
     }
 
     protected abstract DeltaSourceBuilderBase<?, ?> getBuilderWithNulls();
 
-    protected abstract DeltaSourceBuilderBase<?, ?> getBuilderForColumns(
-            String[] columnNames,
-            LogicalType[] columnTypes);
-
+    protected abstract DeltaSourceBuilderBase<?, ?> getBuilderForColumns(String[] columnNames);
 
     /**
      * @return Delta source builder that uses invalid combination od mutually excluded options set
@@ -218,6 +185,18 @@ public abstract class RowDataDeltaSourceBuilderTestBase {
             return Optional.of(e);
         }
         return Optional.empty();
+    }
+
+    protected void mockDeltaTableForSchema(StructField[] fields) {
+        deltaLogStatic = Mockito.mockStatic(DeltaLog.class);
+        deltaLogStatic.when(() -> DeltaLog.forTable(any(Configuration.class), anyString()))
+            .thenReturn(this.deltaLog);
+
+        when(headSnapshot.getMetadata()).thenReturn(metadata);
+        when(metadata.getSchema())
+            .thenReturn(
+                new StructType(fields)
+            );
     }
 
 }

--- a/flink/src/test/java/io/delta/flink/source/SourceExamples.java
+++ b/flink/src/test/java/io/delta/flink/source/SourceExamples.java
@@ -1,43 +1,18 @@
 package io.delta.flink.source;
 
-import java.util.Arrays;
-
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.CharType;
-import org.apache.flink.table.types.logical.IntType;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.hadoop.conf.Configuration;
 
 public class SourceExamples {
-
-    protected static final LogicalType[] COLUMN_TYPES =
-        {new CharType(), new CharType(), new IntType()};
-
-    protected static final String[] COLUMN_NAMES = {"name", "surname", "age"};
 
     public void builderBounded() {
         Configuration hadoopConf = new Configuration();
 
         DeltaSource<RowData> source = DeltaSource.forBoundedRowData(
                 new Path("s3://some/path"),
-                COLUMN_NAMES,
-                COLUMN_TYPES,
                 hadoopConf
             )
-            .build();
-    }
-
-    public void builderBoundedWithPartitions() {
-        Configuration hadoopConf = new Configuration();
-
-        DeltaSource<RowData> source = DeltaSource.forBoundedRowData(
-                new Path("s3://some/path"),
-                COLUMN_NAMES,
-                COLUMN_TYPES,
-                hadoopConf
-            )
-            .partitionColumns(Arrays.asList("col1", "col2"))
             .build();
     }
 
@@ -46,8 +21,6 @@ public class SourceExamples {
 
         DeltaSource<RowData> source = DeltaSource.forContinuousRowData(
                 new Path("s3://some/path"),
-                COLUMN_NAMES,
-                COLUMN_TYPES,
                 hadoopConf
             )
             .build();
@@ -58,11 +31,8 @@ public class SourceExamples {
 
         DeltaSource<RowData> source = DeltaSource.forContinuousRowData(
                 new Path("s3://some/path"),
-                COLUMN_NAMES,
-                COLUMN_TYPES,
                 hadoopConf
             )
-            .partitionColumns(Arrays.asList("col1", "col2"))
             .build();
     }
 
@@ -71,8 +41,6 @@ public class SourceExamples {
 
         DeltaSource<RowData> source = DeltaSource.forBoundedRowData(
                 new Path("s3://some/path"),
-                COLUMN_NAMES,
-                COLUMN_TYPES,
                 hadoopConf
             )
             .versionAsOf(10)
@@ -84,8 +52,6 @@ public class SourceExamples {
 
         DeltaSource<RowData> source = DeltaSource.forContinuousRowData(
                 new Path("s3://some/path"),
-                COLUMN_NAMES,
-                COLUMN_TYPES,
                 hadoopConf
             )
             .updateCheckIntervalMillis(1000)


### PR DESCRIPTION
PR Plan:
PR 5 - Option support in Bounded Mode
PR 6 - Continuous mode without monitoring for changes
PR 6.1 - Package Refactoring
PR 7 - Monitoring for changes in Continuous mode
PR 7.1 - More tests for PR 7 including IT case tests for Continuous mode.
PR 9 - Builder
**PR 10 - Builder refactoring to extract Schema from Delta Log.**
PR 11 - Partition Support using Delta log to identify partition columns.
PR 12 - Get BATCH_SIZE for Format builder from Source options - this value is currently hardcoded. And additional  builder option validation and type safety.

-- All functionalities are in place up to this point. The following PRs are extra tests, eventual bug fixes and code/javadoc adjustments. --

~~PR 11 - Annotate with @deprecated  Sink's builder methods that names starts from "with". Add new ones without "with" prefix and overload partitions with List argument for Sink.~~

PR 11 - Add validation for option names and values including using not applicable options for given mode via generic option method.
PR 12 - Additional IT tests including all options and end to end tests using Source and Sink.

While @kristoffSC is on vacation
@tdas + @scottsand-db to review public API
Once Krzysztof is back
README / docs
QA
end-to-end integration tests - using Sink to write, Source to read, etc.
more examples / migrate examples from internal flink module to examples folder

TODOs and other improvements planed as next:

- Use index for keeping track of already processed paths in SnapshotProcessor - needs new Delta API.
- Do do not create snapshot when streaming only changes (startingVersion or startingTimestamp option used). - needs new Delta API since for startingTimestamp we still need to create a snapshot. There is no API like deltaLog.getChangesFromTimestamp(....)
- Refactor Test util classes to make them common for sink and source.
- Re-visit Delta Standalone APIs for when the source see's metadata/protocol actions. Update ActionProcessor class to handle MetaData and Protocol Actions
- Enhanced DeltaLog.java with `Iterator<VersionLog> getChangesFromTimestamp(long timestamp, boolean failOnDataLoss);` and us it in Delta Source connector for better support of `startingTimestamp` option.