### PR TITLE
Delta-467_Flink_1.15 - fix data loss on Delta Sink due to skipping late RPC calls to GlobalCommitter.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -694,7 +694,7 @@ def flinkScalaVersion(scalaBinaryVersion: String): String = {
   }
 }
 
-val flinkVersion = "1.14.0"
+val flinkVersion = "1.15.2"
 lazy val flink = (project in file("flink"))
   .dependsOn(standaloneCosmetic % "provided")
   .enablePlugins(GenJavadocPlugin, JavaUnidocPlugin)
@@ -725,14 +725,17 @@ lazy val flink = (project in file("flink"))
         </developers>,
     crossPaths := false,
     libraryDependencies ++= Seq(
-      "org.apache.flink" % ("flink-parquet_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion % "provided",
+      "org.apache.flink" % "flink-parquet" % flinkVersion % "provided",
       "org.apache.flink" % "flink-table-common" % flinkVersion % "provided",
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",
+      "org.apache.flink" % "flink-connector-files" % flinkVersion % "provided",
       "org.apache.flink" % "flink-connector-files" % flinkVersion % "test" classifier "tests",
-      "org.apache.flink" % ("flink-table-runtime_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion % "provided",
+      "org.apache.flink" % "flink-table-runtime" % flinkVersion % "provided",
+      "org.apache.flink" % "flink-scala_2.12" % flinkVersion % "provided",
+      "org.apache.flink" % "flink-runtime-web" % flinkVersion % "test",
       "org.apache.flink" % "flink-connector-test-utils" % flinkVersion % "test",
-      "org.apache.flink" % ("flink-clients_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion % "test",
-      "org.apache.flink" % ("flink-test-utils_" + flinkScalaVersion(scalaBinaryVersion.value)) % flinkVersion % "test",
+      "org.apache.flink" % "flink-clients" % flinkVersion % "test",
+      "org.apache.flink" % "flink-test-utils" % flinkVersion % "test",
       "org.apache.hadoop" % "hadoop-common" % hadoopVersion % "test" classifier "tests",
       "org.mockito" % "mockito-inline" % "3.8.0" % "test",
       "net.aichler" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test,

--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -59,7 +59,7 @@ lazy val helloWorld = (project in file("hello-world")) settings (
   extraMavenRepo
 )
 
-val flinkVersion = "1.14.0"
+val flinkVersion = "1.15.2"
 val flinkHadoopVersion = "3.1.0"
 lazy val flinkExample = (project in file("flink-example")) settings (
   name := "flink",

--- a/examples/flink-example/pom.xml
+++ b/examples/flink-example/pom.xml
@@ -29,7 +29,7 @@ limitations under the License.-->
         <staging.repo.url>""</staging.repo.url>
         <scala.main.version>2.12</scala.main.version>
         <connectors.version>0.5.1-SNAPSHOT</connectors.version>
-        <flink-version>1.14.5</flink-version>
+        <flink-version>1.15.2</flink-version>
         <hadoop-version>3.1.0</hadoop-version>
         <log4j.version>2.12.1</log4j.version>
     </properties>
@@ -54,12 +54,12 @@ limitations under the License.-->
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-clients_${scala.main.version}</artifactId>
+            <artifactId>flink-clients</artifactId>
             <version>${flink-version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-parquet_${scala.main.version}</artifactId>
+            <artifactId>flink-parquet</artifactId>
             <version>${flink-version}</version>
         </dependency>
         <dependency>
@@ -75,7 +75,7 @@ limitations under the License.-->
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-runtime_${scala.main.version}</artifactId>
+            <artifactId>flink-table-runtime</artifactId>
             <version>${flink-version}</version>
             <scope>${flink.scope}</scope>
         </dependency>

--- a/flink/README.md
+++ b/flink/README.md
@@ -39,7 +39,7 @@ Depending on the version of the connector you can use it with following Apache F
 |:-------------------:|:---------------------:|
 |  0.4.x (Sink Only)  | 1.12.0 <= X <= 1.14.5 |
 |        0.5.0        | 1.13.0 <= X <= 1.13.6 |
-|   0.5.1-SNAPSHOT    | 1.14.0 <= X <= 1.14.5 |
+|   0.5.1-SNAPSHOT    |      X >= 1.15.0      |
 
 ### APIs
 

--- a/flink/src/main/java/io/delta/flink/internal/ConnectorUtils.java
+++ b/flink/src/main/java/io/delta/flink/internal/ConnectorUtils.java
@@ -1,0 +1,33 @@
+package io.delta.flink.internal;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+public class ConnectorUtils {
+
+    /**
+     * Given a path `child`: 1. Returns `child` if the path is already relative 2. Tries
+     * relativizing `child` with respect to `basePath` a) If the `child` doesn't live within the
+     * same base path, returns `child` as is b) If `child` lives in a different FileSystem, throws
+     * an exception Note that `child` may physically be pointing to a path within `basePath`, but
+     * may logically belong to a different FileSystem, e.g. DBFS mount points and direct S3 paths.
+     */
+    public static String tryRelativizePath(FileSystem fs, Path basePath, Path child) {
+
+        if (child.isAbsolute()) {
+            try {
+                // We can map multiple schemes to the same `FileSystem` class, but `FileSystem
+                // .getScheme` is usually just a hard-coded string. Hence, we need to use the
+                // scheme of the URI that we use to create the FileSystem here.
+                return new Path(
+                    fs.makeQualified(basePath).toUri()
+                        .relativize(fs.makeQualified(child).toUri())).toString();
+            } catch (Exception e) {
+                throw new IllegalArgumentException(
+                    String.format("Failed to relativize the path (%s)", child), e);
+            }
+        }
+        return child.toString();
+    }
+
+}

--- a/flink/src/main/java/io/delta/flink/internal/options/OptionValidator.java
+++ b/flink/src/main/java/io/delta/flink/internal/options/OptionValidator.java
@@ -10,7 +10,7 @@ import org.apache.flink.core.fs.Path;
  *
  * Setting of an option is allowed for known option names. For invalid options, the validation
  * throws {@link DeltaOptionValidationException}. Known option names are passed via constructor
- * parameter {@param validOptions}.
+ * parameter {@code validOptions}.
  *
  * This is an internal class meant for connector implementations only.
  * Usage example (for sink):

--- a/flink/src/main/java/io/delta/flink/sink/internal/DeltaPartitionComputer.java
+++ b/flink/src/main/java/io/delta/flink/sink/internal/DeltaPartitionComputer.java
@@ -53,8 +53,7 @@ public interface DeltaPartitionComputer<T> extends Serializable {
          * @param partitionColumns list of partition column names in the order they should be
          *                         applied when creating a destination path
          */
-        public DeltaRowDataPartitionComputer(RowType rowType,
-                                             String[] partitionColumns) {
+        public DeltaRowDataPartitionComputer(RowType rowType, String[] partitionColumns) {
             this(rowType, partitionColumns, new LinkedHashMap<>());
         }
 
@@ -67,9 +66,10 @@ public interface DeltaPartitionComputer<T> extends Serializable {
          * @param staticPartitionSpec static values for partitions that should set explicitly
          *                            instead of being derived from the content of the records
          */
-        public DeltaRowDataPartitionComputer(RowType rowType,
-                                             String[] partitionColumns,
-                                             LinkedHashMap<String, String> staticPartitionSpec) {
+        public DeltaRowDataPartitionComputer(
+                RowType rowType,
+                String[] partitionColumns,
+                LinkedHashMap<String, String> staticPartitionSpec) {
             this.rowType = rowType;
             this.partitionColumns = partitionColumns;
             this.staticPartitionSpec = staticPartitionSpec;
@@ -77,8 +77,8 @@ public interface DeltaPartitionComputer<T> extends Serializable {
 
         @Override
         public LinkedHashMap<String, String> generatePartitionValues(
-            RowData element,
-            BucketAssigner.Context context) {
+                RowData element,
+                BucketAssigner.Context context) {
             LinkedHashMap<String, String> partitionValues = new LinkedHashMap<>();
 
             for (String partitionKey : partitionColumns) {

--- a/flink/src/main/java/io/delta/flink/sink/internal/committer/DeltaCommitter.java
+++ b/flink/src/main/java/io/delta/flink/sink/internal/committer/DeltaCommitter.java
@@ -26,7 +26,6 @@ import io.delta.flink.sink.DeltaSink;
 import io.delta.flink.sink.internal.committables.DeltaCommittable;
 import io.delta.flink.sink.internal.writer.DeltaWriter;
 import org.apache.flink.api.connector.sink.Committer;
-import org.apache.flink.connector.file.sink.FileSink;
 import org.apache.flink.streaming.api.functions.sink.filesystem.BucketWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,9 +38,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * state, created by the {@link io.delta.flink.sink.internal.writer.DeltaWriter}
  * and put them in "finished" state ready to be committed to the DeltaLog during "global" commit.
  *
- * <p> This class behaves almost in the same way as its equivalent
- * {@link org.apache.flink.connector.file.sink.committer.FileCommitter}
- * in the {@link FileSink}. The only differences are:
+ * <p> This class behaves almost in the same way as its Sink V1 equivalent
+ * {@code org.apache.flink.connector.file.sink.committer.FileCommitter} from Flink 1.14.
+ *
+ * The only differences are:
  *
  * <ol>
  *   <li>use of the {@link DeltaCommittable} instead of
@@ -51,7 +51,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *       file's state (as opposite to
  *       {@link org.apache.flink.connector.file.sink.committer.FileCommitter#commit}
  *       because in {@link DeltaWriter#prepareCommit} we always roll all of the in-progress files.
- *       Valid note here is that's also the default {@link FileSink}'s behaviour for all of the
+ *       Valid note here is that's also the default
+ *       {@link org.apache.flink.connector.file.sink.FileSink}'s behaviour for all of the
  *       bulk formats (Parquet included).</li>
  * </ol>
  * <p>
@@ -97,8 +98,7 @@ public class DeltaCommitter implements Committer<DeltaCommittable> {
      * @throws IOException if committing files (e.g. I/O errors occurs)
      */
     @Override
-    public List<DeltaCommittable> commit(
-        List<DeltaCommittable> committables) throws IOException {
+    public List<DeltaCommittable> commit(List<DeltaCommittable> committables) throws IOException {
         for (DeltaCommittable committable : committables) {
             LOG.info("Committing delta committable locally: " +
                 "appId=" + committable.getAppId() +

--- a/flink/src/main/java/io/delta/flink/sink/internal/committer/DeltaCommitter.java
+++ b/flink/src/main/java/io/delta/flink/sink/internal/committer/DeltaCommitter.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
+// TODO PR Flink 1.15 verify javadoc below.
 /**
  * Committer implementation for {@link DeltaSink}.
  *
@@ -38,10 +39,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * state, created by the {@link io.delta.flink.sink.internal.writer.DeltaWriter}
  * and put them in "finished" state ready to be committed to the DeltaLog during "global" commit.
  *
- * <p> This class behaves almost in the same way as its Sink V1 equivalent
- * {@code org.apache.flink.connector.file.sink.committer.FileCommitter} from Flink 1.14.
- *
- * The only differences are:
+ * <p> This class behaves almost in the same way as its equivalent
+ * {@link org.apache.flink.connector.file.sink.committer.FileCommitter}
+ * in the {@link org.apache.flink.connector.file.sink.FileSink}. The only differences are:
  *
  * <ol>
  *   <li>use of the {@link DeltaCommittable} instead of

--- a/flink/src/main/java/io/delta/flink/sink/internal/committer/DeltaGlobalCommitter.java
+++ b/flink/src/main/java/io/delta/flink/sink/internal/committer/DeltaGlobalCommitter.java
@@ -105,10 +105,12 @@ public class DeltaGlobalCommitter
      */
     private final boolean mergeSchema;
 
-    public DeltaGlobalCommitter(Configuration conf,
-                                Path basePath,
-                                RowType rowType,
-                                boolean mergeSchema) {
+    public DeltaGlobalCommitter(
+            Configuration conf,
+            Path basePath,
+            RowType rowType,
+            boolean mergeSchema) {
+
         this.conf = conf;
         this.basePath = basePath;
         this.rowType = rowType;
@@ -131,7 +133,7 @@ public class DeltaGlobalCommitter
      */
     @Override
     public List<DeltaGlobalCommittable> filterRecoveredCommittables(
-        List<DeltaGlobalCommittable> globalCommittables) {
+            List<DeltaGlobalCommittable> globalCommittables) {
         return globalCommittables;
     }
 

--- a/flink/src/main/java/io/delta/flink/sink/internal/writer/DeltaWriterBucket.java
+++ b/flink/src/main/java/io/delta/flink/sink/internal/writer/DeltaWriterBucket.java
@@ -96,6 +96,7 @@ public class DeltaWriterBucket<IN> {
     private static final Logger LOG = LoggerFactory.getLogger(DeltaWriterBucket.class);
 
     public static final String RECORDS_WRITTEN_METRIC_NAME = "DeltaSinkRecordsWritten";
+
     public static final String BYTES_WRITTEN_METRIC_NAME = "DeltaSinkBytesWritten";
 
     private final String bucketId;

--- a/flink/src/main/java/io/delta/flink/source/internal/DeltaPartitionFieldExtractor.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/DeltaPartitionFieldExtractor.java
@@ -4,8 +4,8 @@ import java.util.Map;
 
 import io.delta.flink.source.internal.exceptions.DeltaSourceExceptions;
 import io.delta.flink.source.internal.state.DeltaSourceSplit;
-import org.apache.flink.table.filesystem.PartitionFieldExtractor;
-import org.apache.flink.table.filesystem.RowPartitionComputer;
+import org.apache.flink.connector.file.table.PartitionFieldExtractor;
+import org.apache.flink.connector.file.table.RowPartitionComputer;
 import org.apache.flink.table.types.logical.LogicalType;
 
 /**

--- a/flink/src/main/java/io/delta/flink/source/internal/builder/RowBuilderUtils.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/builder/RowBuilderUtils.java
@@ -3,12 +3,12 @@ package io.delta.flink.source.internal.builder;
 import java.util.List;
 
 import io.delta.flink.source.internal.state.DeltaSourceSplit;
+import org.apache.flink.connector.file.table.PartitionFieldExtractor;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.parquet.ParquetColumnarRowInputFormat;
 import org.apache.flink.formats.parquet.vector.ColumnBatchFactory;
-import org.apache.flink.table.data.vector.ColumnVector;
-import org.apache.flink.table.data.vector.VectorizedColumnBatch;
-import org.apache.flink.table.filesystem.PartitionFieldExtractor;
+import org.apache.flink.table.data.columnar.vector.ColumnVector;
+import org.apache.flink.table.data.columnar.vector.VectorizedColumnBatch;
 import org.apache.flink.table.types.logical.RowType;
 import static org.apache.flink.formats.parquet.vector.ParquetSplitReaderUtil.createVectorFromConstant;
 

--- a/flink/src/main/java/io/delta/flink/source/internal/builder/RowDataFormat.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/builder/RowDataFormat.java
@@ -1,8 +1,10 @@
 package io.delta.flink.source.internal.builder;
 
+import java.io.IOException;
+
 import io.delta.flink.source.internal.state.DeltaSourceSplit;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.formats.parquet.ParquetColumnarRowInputFormat;
-import org.apache.flink.formats.parquet.vector.ColumnBatchFactory;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.hadoop.conf.Configuration;
@@ -10,34 +12,41 @@ import org.apache.hadoop.conf.Configuration;
 /**
  * Implementation of {@link DeltaBulkFormat} for {@link RowData} type.
  */
-public class RowDataFormat extends ParquetColumnarRowInputFormat<DeltaSourceSplit>
-    implements DeltaBulkFormat<RowData> {
+public class RowDataFormat implements DeltaBulkFormat<RowData> {
 
-    // Making this constructor package protected to make sure that only RowDataFormatBuilder can
-    // initialize object of this class.
-    RowDataFormat(
-        Configuration hadoopConfig,
-        RowType projectedType,
-        int batchSize,
-        boolean isUtcTimestamp,
-        boolean isCaseSensitive) {
-        super(hadoopConfig, projectedType, batchSize, isUtcTimestamp, isCaseSensitive);
-    }
+    private final ParquetColumnarRowInputFormat<DeltaSourceSplit> decoratedInputFormat;
 
-    RowDataFormat(
-        Configuration hadoopConfig,
-        RowType projectedRowType,
-        RowType producedRowType,
-        ColumnBatchFactory<DeltaSourceSplit> factory,
-        int batchSize,
-        boolean parquetUtcTimestamp,
-        boolean parquetCaseSensitive) {
-        super(hadoopConfig, projectedRowType, producedRowType, factory, batchSize,
-            parquetUtcTimestamp, parquetCaseSensitive);
+    public RowDataFormat(ParquetColumnarRowInputFormat<DeltaSourceSplit> inputFormat) {
+        this.decoratedInputFormat = inputFormat;
     }
 
     public static RowDataFormatBuilder builder(RowType rowType, Configuration hadoopConfiguration) {
         return new RowDataFormatBuilder(rowType, hadoopConfiguration);
     }
 
+    @Override
+    public Reader<RowData> createReader(
+            org.apache.flink.configuration.Configuration configuration,
+            DeltaSourceSplit deltaSourceSplit) throws IOException {
+
+        return this.decoratedInputFormat.createReader(configuration, deltaSourceSplit);
+    }
+
+    @Override
+    public Reader<RowData> restoreReader(
+            org.apache.flink.configuration.Configuration configuration,
+            DeltaSourceSplit deltaSourceSplit) throws IOException {
+
+        return this.decoratedInputFormat.restoreReader(configuration, deltaSourceSplit);
+    }
+
+    @Override
+    public boolean isSplittable() {
+        return this.decoratedInputFormat.isSplittable();
+    }
+
+    @Override
+    public TypeInformation<RowData> getProducedType() {
+        return this.decoratedInputFormat.getProducedType();
+    }
 }

--- a/flink/src/main/java/io/delta/flink/source/internal/state/DeltaPendingSplitsCheckpointSerializer.java
+++ b/flink/src/main/java/io/delta/flink/source/internal/state/DeltaPendingSplitsCheckpointSerializer.java
@@ -8,7 +8,6 @@ import java.nio.charset.StandardCharsets;
 import io.delta.flink.source.internal.utils.SourceUtils;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.api.connector.source.SplitEnumerator;
-import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.PendingSplitsCheckpoint;
 import org.apache.flink.connector.file.src.PendingSplitsCheckpointSerializer;
 import org.apache.flink.core.fs.Path;
@@ -46,8 +45,9 @@ public class DeltaPendingSplitsCheckpointSerializer<SplitT extends DeltaSourceSp
     private static final int VERSION = 1;
 
     /**
-     * A de/serializer for {@link FileSourceSplit} that {@link DeltaSourceSplit} extends. It handles
-     * de/serialization all fields inherited from {@code FileSourceSplit}
+     * A de/serializer for {@link org.apache.flink.connector.file.src.FileSourceSplit} that {@link
+     * DeltaSourceSplit} extends. It handles de/serialization all fields inherited from {@code
+     * FileSourceSplit}
      */
     private final PendingSplitsCheckpointSerializer<SplitT> decoratedSerDe;
 

--- a/flink/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/DeltaBulkPartWriter.java
+++ b/flink/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/DeltaBulkPartWriter.java
@@ -51,7 +51,7 @@ import org.apache.flink.util.Preconditions;
  *     <li>Since it's a class member of {@link DeltaInProgressPart} it shares its life span as
  *         well</li>
  *     <li>Instances of this class are being created inside
- *         {@link io.delta.flink.sink.internal.writer.DeltaWriterBucket#rollPartFile}
+ *         {@link io.delta.flink.sink.internal.writer.DeltaWriterBucket}
  *         method every time a bucket processes the first event or if the previously opened file
  *         met conditions for rolling (e.g. size threshold)</li>
  *     <li>Its life span holds as long as the underlying file stays in an in-progress state (so
@@ -78,10 +78,10 @@ public class DeltaBulkPartWriter<IN, BucketID>
     private boolean closed = false;
 
     public DeltaBulkPartWriter(
-        final BucketID bucketId,
-        final RecoverableFsDataOutputStream currentPartStream,
-        final BulkWriter<IN> writer,
-        final long creationTime) {
+            BucketID bucketId,
+            RecoverableFsDataOutputStream currentPartStream,
+            BulkWriter<IN> writer,
+            long creationTime) {
         super(bucketId, creationTime);
         this.currentPartStream = currentPartStream;
         this.writer = Preconditions.checkNotNull(writer);

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkBatchExecutionITCase.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkBatchExecutionITCase.java
@@ -24,24 +24,40 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
 import io.delta.flink.sink.internal.DeltaSinkInternal;
+import io.delta.flink.sink.internal.committables.DeltaCommittable;
+import io.delta.flink.sink.internal.committables.DeltaGlobalCommittable;
+import io.delta.flink.sink.internal.committer.DeltaGlobalCommitter;
+import io.delta.flink.sink.internal.writer.DeltaWriterBucketState;
 import io.delta.flink.sink.utils.DeltaSinkTestUtils;
 import io.delta.flink.utils.DeltaTestUtils;
 import io.delta.flink.utils.TestParquetReader;
 import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.api.connector.sink.GlobalCommitter;
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
-import org.apache.flink.connector.file.sink.BatchExecutionFileSinkITCase;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.table.data.RowData;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.delta.standalone.DeltaLog;
 import io.delta.standalone.actions.AddFile;
@@ -50,35 +66,71 @@ import io.delta.standalone.actions.CommitInfo;
 /**
  * Tests the functionality of the {@link DeltaSink} in BATCH mode.
  */
-public class DeltaSinkBatchExecutionITCase extends BatchExecutionFileSinkITCase {
+public class DeltaSinkBatchExecutionITCase {
+
+    private static final int NUM_SINKS = 3;
+
+    private static final int NUM_RECORDS = 10000;
+
+    public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
 
     private String deltaTablePath;
 
-    @Before
+    @BeforeAll
+    public static void beforeAll() throws IOException {
+        TEMPORARY_FOLDER.create();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        TEMPORARY_FOLDER.delete();
+    }
+
+    @BeforeEach
     public void setup() {
         try {
             deltaTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
-            DeltaTestUtils.initTestForNonPartitionedTable(deltaTablePath);
         } catch (IOException e) {
             throw new RuntimeException("Weren't able to setup the test dependencies", e);
         }
     }
 
-    @Override
-    @Test
-    public void testFileSink() throws Exception {
-        runDeltaSinkTest();
+    /**
+     * Arguments for parametrized Delta Sink test.
+     * Parameters are:
+     * <ul>
+     *     <li>isPartitioned</li>
+     *     <li>triggerFailover</li>
+     * </ul>
+     */
+    private static Stream<Arguments> deltaSinkArguments() {
+        return Stream.of(
+            Arguments.of(false, false),
+            Arguments.of(true, false),
+            Arguments.of(false, true),
+            Arguments.of(true, true)
+        );
     }
 
-    public void runDeltaSinkTest() throws Exception {
+    @ParameterizedTest(name = "isPartitioned = {0}, triggerFailover = {1}")
+    @MethodSource("deltaSinkArguments")
+    public void testFileSink(boolean isPartitioned, boolean triggerFailover) throws Exception {
+
+        initSourceFolder(isPartitioned, deltaTablePath);
+
         // GIVEN
         DeltaLog deltaLog = DeltaLog.forTable(DeltaTestUtils.getHadoopConf(), deltaTablePath);
         List<AddFile> initialDeltaFiles = deltaLog.snapshot().getAllFiles();
         int initialTableRecordsCount = TestParquetReader.readAndValidateAllTableRecords(deltaLog);
         long initialVersion = deltaLog.snapshot().getVersion();
-        assertEquals(2, initialDeltaFiles.size());
 
-        JobGraph jobGraph = createJobGraph(deltaTablePath);
+        if (isPartitioned) {
+            assertEquals(1, initialDeltaFiles.size());
+        } else {
+            assertEquals(2, initialDeltaFiles.size());
+        }
+
+        JobGraph jobGraph = createJobGraph(deltaTablePath, isPartitioned, triggerFailover);
 
         // WHEN
         try (MiniCluster miniCluster = DeltaSinkTestUtils.getMiniCluster()) {
@@ -95,8 +147,10 @@ public class DeltaSinkBatchExecutionITCase extends BatchExecutionFileSinkITCase 
         assertTrue(finalDeltaFiles.size() > initialDeltaFiles.size());
         Iterator<Long> it = LongStream.range(
             initialVersion + 1, deltaLog.snapshot().getVersion() + 1).iterator();
+
         long totalRowsAdded = 0;
         long totalAddedFiles = 0;
+
         while (it.hasNext()) {
             long currentVersion = it.next();
             CommitInfo currentCommitInfo = deltaLog.getCommitInfoAt(currentVersion);
@@ -113,14 +167,33 @@ public class DeltaSinkBatchExecutionITCase extends BatchExecutionFileSinkITCase 
         assertEquals(NUM_RECORDS, totalRowsAdded);
     }
 
-    @Override
-    protected JobGraph createJobGraph(String path) {
-        StreamExecutionEnvironment env = getTestStreamEnv();
+    private String initSourceFolder(boolean isPartitioned, String deltaTablePath) {
+        try {
+            if (isPartitioned) {
+                DeltaTestUtils.initTestForPartitionedTable(deltaTablePath);
+            } else {
+                DeltaTestUtils.initTestForNonPartitionedTable(deltaTablePath);
+            }
 
-        DeltaSinkInternal<RowData> deltaSink = DeltaSinkTestUtils.createDeltaSink(
-            path,
-            false // isTablePartitioned
-        );
+            return deltaTablePath;
+        } catch (IOException e) {
+            throw new RuntimeException("Weren't able to setup the test dependencies", e);
+        }
+    }
+
+    protected JobGraph createJobGraph(
+            String deltaTablePath,
+            boolean isPartitioned,
+            boolean triggerFailover) {
+
+        StreamExecutionEnvironment env = getTestStreamEnv(triggerFailover);
+
+        Sink<RowData, DeltaCommittable, DeltaWriterBucketState, DeltaGlobalCommittable> deltaSink =
+            DeltaSinkTestUtils.createDeltaSink(deltaTablePath, isPartitioned);
+
+        if (triggerFailover) {
+            deltaSink = new FailoverDeltaSink<>((DeltaSinkInternal<RowData>) deltaSink);
+        }
 
         env.fromCollection(DeltaSinkTestUtils.getTestRowData(NUM_RECORDS))
             .setParallelism(1)
@@ -131,12 +204,112 @@ public class DeltaSinkBatchExecutionITCase extends BatchExecutionFileSinkITCase 
         return streamGraph.getJobGraph();
     }
 
-    private StreamExecutionEnvironment getTestStreamEnv() {
+    private StreamExecutionEnvironment getTestStreamEnv(boolean triggerFailover) {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         Configuration config = new Configuration();
         config.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
         env.configure(config, getClass().getClassLoader());
+
+        if (triggerFailover) {
+            env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, Time.milliseconds(100)));
+        } else {
+            env.setRestartStrategy(RestartStrategies.noRestart());
+        }
+
         return env;
+    }
+
+    private static class FailoverDeltaSink<IN>
+        implements Sink<IN, DeltaCommittable, DeltaWriterBucketState, DeltaGlobalCommittable> {
+
+        private final DeltaSinkInternal<IN> decoratedSink;
+
+        private FailoverDeltaSink(DeltaSinkInternal<IN> decoratedSink) {
+            this.decoratedSink = decoratedSink;
+        }
+
+        @Override
+        public SinkWriter<IN, DeltaCommittable, DeltaWriterBucketState> createWriter(
+            InitContext initContext, List<DeltaWriterBucketState> list) throws IOException {
+            return this.decoratedSink.createWriter(initContext, list);
+        }
+
+        @Override
+        public Optional<SimpleVersionedSerializer<DeltaWriterBucketState>>
+            getWriterStateSerializer() {
+
+            return this.decoratedSink.getWriterStateSerializer();
+        }
+
+        @Override
+        public Optional<Committer<DeltaCommittable>> createCommitter() throws IOException {
+            return this.decoratedSink.createCommitter();
+        }
+
+        @Override
+        public Optional<GlobalCommitter<DeltaCommittable, DeltaGlobalCommittable>>
+            createGlobalCommitter() throws IOException {
+
+            return Optional.of(new FailoverDeltaGlobalCommitter(
+                (DeltaGlobalCommitter) this.decoratedSink.createGlobalCommitter().get()));
+        }
+
+        @Override
+        public Optional<SimpleVersionedSerializer<DeltaCommittable>> getCommittableSerializer() {
+            return this.decoratedSink.getCommittableSerializer();
+        }
+
+        @Override
+        public Optional<SimpleVersionedSerializer<DeltaGlobalCommittable>>
+            getGlobalCommittableSerializer() {
+            return this.decoratedSink.getGlobalCommittableSerializer();
+        }
+    }
+
+    private static class FailoverDeltaGlobalCommitter
+        implements GlobalCommitter<DeltaCommittable, DeltaGlobalCommittable> {
+
+        private static boolean THROW_EXCEPTION = true;
+
+        private final DeltaGlobalCommitter decoratedGlobalCommitter;
+
+        private FailoverDeltaGlobalCommitter(DeltaGlobalCommitter decoratedGlobalCommitter) {
+            this.decoratedGlobalCommitter = decoratedGlobalCommitter;
+        }
+
+        @Override
+        public List<DeltaGlobalCommittable> filterRecoveredCommittables(
+            List<DeltaGlobalCommittable> list) throws IOException {
+            return this.decoratedGlobalCommitter.filterRecoveredCommittables(list);
+        }
+
+        @Override
+        public DeltaGlobalCommittable combine(List<DeltaCommittable> list) throws IOException {
+            return this.decoratedGlobalCommitter.combine(list);
+        }
+
+        @Override
+        public List<DeltaGlobalCommittable> commit(List<DeltaGlobalCommittable> list)
+            throws IOException, InterruptedException {
+            try {
+                if (THROW_EXCEPTION) {
+                    throw new RuntimeException("Designed Global Committer Exception.");
+                }
+            } finally {
+                THROW_EXCEPTION = false;
+            }
+            return this.decoratedGlobalCommitter.commit(list);
+        }
+
+        @Override
+        public void endOfInput() throws IOException, InterruptedException {
+            this.decoratedGlobalCommitter.endOfInput();
+        }
+
+        @Override
+        public void close() throws Exception {
+            this.decoratedGlobalCommitter.close();
+        }
     }
 }

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkExecutionITCaseBase.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkExecutionITCaseBase.java
@@ -1,0 +1,109 @@
+package io.delta.flink.sink;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import io.delta.flink.sink.internal.DeltaSinkInternal;
+import io.delta.flink.sink.internal.committables.DeltaCommittable;
+import io.delta.flink.sink.internal.committables.DeltaGlobalCommittable;
+import io.delta.flink.sink.internal.committer.DeltaGlobalCommitter;
+import io.delta.flink.sink.internal.writer.DeltaWriterBucketState;
+import io.delta.flink.utils.DeltaTestUtils;
+import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.api.connector.sink.GlobalCommitter;
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.connector.sink.SinkWriter;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+public abstract class DeltaSinkExecutionITCaseBase {
+
+    protected String initSourceFolder(boolean isPartitioned, String deltaTablePath) {
+        try {
+            if (isPartitioned) {
+                DeltaTestUtils.initTestForPartitionedTable(deltaTablePath);
+            } else {
+                DeltaTestUtils.initTestForNonPartitionedTable(deltaTablePath);
+            }
+
+            return deltaTablePath;
+        } catch (IOException e) {
+            throw new RuntimeException("Weren't able to setup the test dependencies", e);
+        }
+    }
+
+    protected abstract static class FailoverDeltaSinkBase<IN>
+        implements Sink<IN, DeltaCommittable, DeltaWriterBucketState, DeltaGlobalCommittable> {
+
+        protected final DeltaSinkInternal<IN> decoratedSink;
+
+        protected FailoverDeltaSinkBase(DeltaSinkInternal<IN> decoratedSink) {
+            this.decoratedSink = decoratedSink;
+        }
+
+        @Override
+        public SinkWriter<IN, DeltaCommittable, DeltaWriterBucketState> createWriter(
+            InitContext initContext, List<DeltaWriterBucketState> list) throws IOException {
+            return this.decoratedSink.createWriter(initContext, list);
+        }
+
+        @Override
+        public Optional<SimpleVersionedSerializer<DeltaWriterBucketState>>
+            getWriterStateSerializer() {
+
+            return this.decoratedSink.getWriterStateSerializer();
+        }
+
+        @Override
+        public Optional<Committer<DeltaCommittable>> createCommitter() throws IOException {
+            return this.decoratedSink.createCommitter();
+        }
+        @Override
+        public Optional<SimpleVersionedSerializer<DeltaCommittable>> getCommittableSerializer() {
+            return this.decoratedSink.getCommittableSerializer();
+        }
+
+        @Override
+        public Optional<SimpleVersionedSerializer<DeltaGlobalCommittable>>
+            getGlobalCommittableSerializer() {
+            return this.decoratedSink.getGlobalCommittableSerializer();
+        }
+    }
+
+    protected abstract static class FailoverDeltaGlobalCommitterBase
+        implements GlobalCommitter<DeltaCommittable, DeltaGlobalCommittable> {
+
+        protected final DeltaGlobalCommitter decoratedGlobalCommitter;
+
+        protected FailoverDeltaGlobalCommitterBase(DeltaGlobalCommitter decoratedGlobalCommitter) {
+            this.decoratedGlobalCommitter = decoratedGlobalCommitter;
+        }
+
+        @Override
+        public List<DeltaGlobalCommittable> filterRecoveredCommittables(
+            List<DeltaGlobalCommittable> list) throws IOException {
+            return this.decoratedGlobalCommitter.filterRecoveredCommittables(list);
+        }
+
+        @Override
+        public DeltaGlobalCommittable combine(List<DeltaCommittable> list) throws IOException {
+            return this.decoratedGlobalCommitter.combine(list);
+        }
+
+        @Override
+        public void endOfInput() throws IOException, InterruptedException {
+            this.decoratedGlobalCommitter.endOfInput();
+        }
+
+        @Override
+        public void close() throws Exception {
+            this.decoratedGlobalCommitter.close();
+        }
+    }
+
+    protected enum GlobalCommitterExceptionMode {
+        BEFORE_COMMIT,
+        AFTER_COMMIT,
+        NONE
+    }
+}

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkStreamingExecutionITCase.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkStreamingExecutionITCase.java
@@ -119,16 +119,27 @@ public class DeltaSinkStreamingExecutionITCase {
         LATCH_MAP.remove(latchId);
     }
 
+    /**
+     * Arguments for parametrized Delta Sink test.
+     * Parameters are:
+     * <ul>
+     *     <li>isPartitioned</li>
+     *     <li>triggerFailover</li>
+     * </ul>
+     */
     private static Stream<Arguments> deltaSinkArguments() {
         return Stream.of(
             Arguments.of(false, false),
-            Arguments.of(false, true),
-            Arguments.of(true, false),
-            Arguments.of(true, true)
+            Arguments.of(true, false)
+        // TODO Flink_1.15 this should be uncomment when Flink 1.15.3 will be released.
+        //  This comment out variations run test for failover scenarios.
+        //  When Flink 1.15.3 will be released whe should use it in connector's dependencies.
+        // Arguments.of(false, true),
+        // Arguments.of(true, true)
         );
     }
 
-    @ParameterizedTest(name = "triggerFailover = {0}, isPartitioned = {1}")
+    @ParameterizedTest(name = "isPartitioned = {0}, triggerFailover = {1}")
     @MethodSource("deltaSinkArguments")
     public void testFileSink(boolean isPartitioned, boolean triggerFailover) throws Exception {
 
@@ -190,6 +201,7 @@ public class DeltaSinkStreamingExecutionITCase {
             String deltaTablePath,
             boolean triggerFailover,
             boolean isPartitioned) throws Exception {
+
         // GIVEN
         DeltaLog deltaLog = DeltaLog.forTable(DeltaTestUtils.getHadoopConf(), deltaTablePath);
         List<AddFile> initialDeltaFiles = deltaLog.snapshot().getAllFiles();
@@ -245,6 +257,7 @@ public class DeltaSinkStreamingExecutionITCase {
             String deltaTablePath,
             boolean triggerFailover,
             boolean isPartitioned) {
+
         StreamExecutionEnvironment env = getTestStreamEnv(triggerFailover);
 
         env.addSource(new DeltaStreamingExecutionTestSource(latchId, NUM_RECORDS, triggerFailover))

--- a/flink/src/test/java/io/delta/flink/sink/DeltaSinkStreamingExecutionITCase.java
+++ b/flink/src/test/java/io/delta/flink/sink/DeltaSinkStreamingExecutionITCase.java
@@ -22,11 +22,14 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -34,6 +37,11 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import io.delta.flink.sink.internal.DeltaSinkInternal;
+import io.delta.flink.sink.internal.committables.DeltaCommittable;
+import io.delta.flink.sink.internal.committables.DeltaGlobalCommittable;
+import io.delta.flink.sink.internal.committer.DeltaGlobalCommitter;
+import io.delta.flink.sink.internal.writer.DeltaWriterBucketState;
 import io.delta.flink.sink.utils.CheckpointCountingSource;
 import io.delta.flink.sink.utils.DeltaSinkTestUtils;
 import io.delta.flink.utils.DeltaTestUtils;
@@ -44,6 +52,8 @@ import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.connector.sink.GlobalCommitter;
+import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.connector.file.sink.StreamingExecutionFileSinkITCase;
@@ -58,14 +68,16 @@ import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunctio
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.rules.TemporaryFolder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -79,7 +91,7 @@ import io.delta.standalone.actions.CommitInfo;
 /**
  * Tests the functionality of the {@link DeltaSink} in STREAMING mode.
  */
-public class DeltaSinkStreamingExecutionITCase {
+public class DeltaSinkStreamingExecutionITCase extends DeltaSinkExecutionITCaseBase {
 
     private static final int NUM_SOURCES = 4;
 
@@ -127,25 +139,94 @@ public class DeltaSinkStreamingExecutionITCase {
      *     <li>triggerFailover</li>
      * </ul>
      */
-    private static Stream<Arguments> deltaSinkArguments() {
-        return Stream.of(
-            Arguments.of(false, false),
-            Arguments.of(true, false)
+    @ParameterizedTest(name = "isPartitioned = {0}, triggerFailover = {1}")
+    @CsvSource({
+        "false, false",
+        "true, false"
         // TODO Flink_1.15 this should be uncomment when Flink 1.15.3 will be released.
         //  This comment out variations run test for failover scenarios.
         //  When Flink 1.15.3 will be released whe should use it in connector's dependencies.
-        // Arguments.of(false, true),
-        // Arguments.of(true, true)
-        );
-    }
-
-    @ParameterizedTest(name = "isPartitioned = {0}, triggerFailover = {1}")
-    @MethodSource("deltaSinkArguments")
+        // "false, true",
+        // "true, true"
+    })
     public void testFileSink(boolean isPartitioned, boolean triggerFailover) throws Exception {
 
         initSourceFolder(isPartitioned, deltaTablePath);
 
-        runDeltaSinkTest(deltaTablePath, triggerFailover, isPartitioned);
+        JobGraph jobGraph = createJobGraphWithFailoverSource(
+            deltaTablePath,
+            triggerFailover,
+            isPartitioned
+        );
+
+        runDeltaSinkTest(deltaTablePath, jobGraph, NUM_RECORDS);
+    }
+
+    /**
+     * This test executes simple source -> sink job with multiple Flink cluster failures caused by
+     * an Exception thrown from {@link GlobalCommitter}. Depending on value of exceptionMode
+     * parameter, exception will be thrown before or after committing data to the Delta log.
+     *
+     * @param exceptionMode whether to throw an exception before or after Delta log commit.
+     */
+    // TODO Flink_1.15 this should be re-enabled when Flink 1.15.3 will be released.
+    //  This test executes failover scenarios.
+    //  When Flink 1.15.3 will be released whe should use it in connector's dependencies.
+    @Disabled
+    @ResourceLock("StreamingFailoverDeltaGlobalCommitter")
+    @ParameterizedTest(name = "isPartitioned = {0}, exceptionMode = {1}")
+    @CsvSource({
+        "false, BEFORE_COMMIT",
+        "false, AFTER_COMMIT",
+        "true, BEFORE_COMMIT",
+        "true, AFTER_COMMIT"
+    })
+    public void testFileSinkWithGlobalCommitterFailover(
+            boolean isPartitioned,
+            GlobalCommitterExceptionMode exceptionMode) throws Exception {
+
+        // GIVEN
+        FailoverDeltaGlobalCommitter.reset();
+
+        assertThat(
+            "Test setup issue. Static FailoverDeltaGlobalCommitter.checkpointCounter field"
+                + " must be reset to 0 before test.",
+            FailoverDeltaGlobalCommitter.checkpointCounter,
+            equalTo(0)
+        );
+
+        assertThat(
+            "Test setup issue. Static FailoverDeltaGlobalCommitter.checkpointCounter"
+                + " designExceptionCounter must be reset to 0 before test.",
+            FailoverDeltaGlobalCommitter.designExceptionCounter,
+            equalTo(0)
+        );
+
+        initSourceFolder(isPartitioned, deltaTablePath);
+        DeltaTestUtils.resetDeltaLogLastModifyTimestamp(deltaTablePath);
+
+        Set<Integer> checkpointsToFailOn = new HashSet<>(Arrays.asList(5, 10, 11, 14));
+
+        int recordsPerCheckpoint = 100;
+        int totalNumberOfCheckpoints = 15;
+        JobGraph jobGraph = createJobGraphWithFailoverGlobalCommitter(
+            deltaTablePath,
+            exceptionMode,
+            recordsPerCheckpoint,
+            totalNumberOfCheckpoints,
+            checkpointsToFailOn,
+            isPartitioned
+        );
+
+        // WHEN/THEN
+        runDeltaSinkTest(deltaTablePath, jobGraph, recordsPerCheckpoint * totalNumberOfCheckpoints);
+
+        assertThat(
+            "Flink test job had fewer exceptions than expected. "
+                + "Please verify test setup, for example Flink Restart Strategy limit.",
+            checkpointsToFailOn.size(),
+            equalTo(FailoverDeltaGlobalCommitter.designExceptionCounter)
+        );
     }
 
     /**
@@ -199,8 +280,8 @@ public class DeltaSinkStreamingExecutionITCase {
 
     public void runDeltaSinkTest(
             String deltaTablePath,
-            boolean triggerFailover,
-            boolean isPartitioned) throws Exception {
+            JobGraph jobGraph,
+            int numOfRecordsPerSource) throws Exception {
 
         // GIVEN
         DeltaLog deltaLog = DeltaLog.forTable(DeltaTestUtils.getHadoopConf(), deltaTablePath);
@@ -211,8 +292,6 @@ public class DeltaSinkStreamingExecutionITCase {
             .readAndValidateAllTableRecords(deltaLog);
         assertEquals(2, initialTableRecordsCount);
 
-        JobGraph jobGraph = createJobGraph(deltaTablePath, triggerFailover, isPartitioned);
-
         // WHEN
         try (MiniCluster miniCluster = DeltaSinkTestUtils.getMiniCluster()) {
             miniCluster.start();
@@ -222,14 +301,19 @@ public class DeltaSinkStreamingExecutionITCase {
         // THEN
         int writtenRecordsCount =
             DeltaSinkTestUtils.validateIfPathContainsParquetFilesWithData(deltaTablePath);
-        assertEquals(NUM_RECORDS * NUM_SOURCES, writtenRecordsCount - initialTableRecordsCount);
+        assertEquals(
+            numOfRecordsPerSource * NUM_SOURCES,
+            writtenRecordsCount - initialTableRecordsCount
+        );
 
         List<AddFile> finalDeltaFiles = deltaLog.update().getAllFiles();
         assertTrue(finalDeltaFiles.size() > initialDeltaFiles.size());
         Iterator<Long> it = LongStream.range(
             initialVersion + 1, deltaLog.snapshot().getVersion() + 1).iterator();
+
         long totalRowsAdded = 0;
         long totalAddedFiles = 0;
+
         while (it.hasNext()) {
             long currentVersion = it.next();
             CommitInfo currentCommitInfo = deltaLog.getCommitInfoAt(currentVersion);
@@ -245,7 +329,7 @@ public class DeltaSinkStreamingExecutionITCase {
         int finalTableRecordsCount = TestParquetReader.readAndValidateAllTableRecords(deltaLog);
 
         assertEquals(finalDeltaFiles.size() - initialDeltaFiles.size(), totalAddedFiles);
-        assertEquals((NUM_RECORDS * NUM_SOURCES), totalRowsAdded);
+        assertEquals(((long) numOfRecordsPerSource * NUM_SOURCES), totalRowsAdded);
         assertEquals(finalTableRecordsCount - initialTableRecordsCount, totalRowsAdded);
     }
 
@@ -253,7 +337,7 @@ public class DeltaSinkStreamingExecutionITCase {
      * Creating the testing job graph in streaming mode. The graph created is [Source] -> [Delta
      * Sink]. The source would trigger failover if required.
      */
-    protected JobGraph createJobGraph(
+    protected JobGraph createJobGraphWithFailoverSource(
             String deltaTablePath,
             boolean triggerFailover,
             boolean isPartitioned) {
@@ -269,6 +353,44 @@ public class DeltaSinkStreamingExecutionITCase {
         return streamGraph.getJobGraph();
     }
 
+    /**
+     * Creating the testing job graph in streaming mode. The graph created is [Source] -> [Delta
+     * Sink]. The sink will contain global committer that will throw an exception before or after
+     * committing to the delta log after certain number of Flink checkpoints.
+     */
+    protected JobGraph createJobGraphWithFailoverGlobalCommitter(
+            String deltaTablePath,
+            GlobalCommitterExceptionMode exceptionMode,
+            int recordsPerCheckpoint,
+            int numberOfCheckpoints,
+            Set<Integer> checkpointsToFailOn,
+            boolean isPartitioned) {
+
+        Preconditions.checkArgument(
+            numberOfCheckpoints > 1,
+            "Number of checkpoints must be at least 2."
+        );
+
+        StreamExecutionEnvironment env = getTestStreamEnv(true);
+
+        Sink<RowData, DeltaCommittable, DeltaWriterBucketState, DeltaGlobalCommittable> deltaSink =
+            DeltaSinkTestUtils.createDeltaSink(deltaTablePath, isPartitioned);
+
+        deltaSink = new FailoverDeltaSink(
+            (DeltaSinkInternal<RowData>) deltaSink,
+            exceptionMode,
+            checkpointsToFailOn
+            );
+
+        env.addSource(new CheckpointCountingSource(recordsPerCheckpoint, numberOfCheckpoints))
+            .setParallelism(NUM_SOURCES)
+            .sinkTo(deltaSink)
+            .setParallelism(NUM_SINKS);
+
+        StreamGraph streamGraph = env.getStreamGraph();
+        return streamGraph.getJobGraph();
+    }
+
     private StreamExecutionEnvironment getTestStreamEnv(boolean triggerFailover) {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
@@ -278,26 +400,12 @@ public class DeltaSinkStreamingExecutionITCase {
         env.enableCheckpointing(1000, CheckpointingMode.EXACTLY_ONCE);
 
         if (triggerFailover) {
-            env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, Time.milliseconds(100)));
+            env.setRestartStrategy(RestartStrategies.fixedDelayRestart(10, Time.milliseconds(100)));
         } else {
             env.setRestartStrategy(RestartStrategies.noRestart());
         }
 
         return env;
-    }
-
-    private String initSourceFolder(boolean isPartitioned, String deltaTablePath) {
-        try {
-            if (isPartitioned) {
-                DeltaTestUtils.initTestForPartitionedTable(deltaTablePath);
-            } else {
-                DeltaTestUtils.initTestForNonPartitionedTable(deltaTablePath);
-            }
-
-            return deltaTablePath;
-        } catch (IOException e) {
-            throw new RuntimeException("Weren't able to setup the test dependencies", e);
-        }
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -431,6 +539,115 @@ public class DeltaSinkStreamingExecutionITCase {
         @Override
         public void cancel() {
             isCanceled = true;
+        }
+    }
+
+    /**
+     * Wrapper for original {@link DeltaSinkInternal} that can be used for IT testing batch jobs.
+     * This implementation will use {@link FailoverDeltaGlobalCommitter} as GlobalCommitter.
+     */
+    private static class FailoverDeltaSink extends FailoverDeltaSinkBase<RowData> {
+
+        private final GlobalCommitterExceptionMode exceptionMode;
+
+        private final Set<Integer> checkpointsToFailOn;
+
+        private FailoverDeltaSink(
+                DeltaSinkInternal<RowData> deltaSink,
+                GlobalCommitterExceptionMode exceptionMode,
+                Set<Integer> checkpointsToFailOn) {
+
+            super(deltaSink);
+            this.exceptionMode = exceptionMode;
+            this.checkpointsToFailOn = checkpointsToFailOn;
+        }
+
+        @Override
+        public Optional<GlobalCommitter<DeltaCommittable, DeltaGlobalCommittable>>
+            createGlobalCommitter() throws IOException {
+
+            return Optional.of(new FailoverDeltaGlobalCommitter(
+                (DeltaGlobalCommitter) this.decoratedSink.createGlobalCommitter().get(),
+                this.exceptionMode,
+                this.checkpointsToFailOn)
+            );
+        }
+    }
+
+    /**
+     * Wrapper for original {@link DeltaGlobalCommitter} that can be used for IT testing Streaming
+     * jobs. This implementation will throw an exception before or after committing data to the
+     * delta log.
+     * <p>
+     * This implementation uses a static fields as a flag, so it cannot be used in multithreading
+     * test setup where there will be multiple tests using this class running at the same time.
+     * This would cause unpredictable results.
+     */
+    private static class FailoverDeltaGlobalCommitter extends FailoverDeltaGlobalCommitterBase {
+
+        /**
+         * Counter for checkpoints that this committer proceeded.
+         */
+        public static int checkpointCounter;
+
+        /**
+         * Counter for number of thrown exceptions.
+         */
+        public static int designExceptionCounter;
+
+        private final GlobalCommitterExceptionMode exceptionMode;
+
+        /**
+         * Checkpoint counts when exception should be thrown.
+         */
+        private final Set<Integer> checkpointsToFailOn;
+
+        private FailoverDeltaGlobalCommitter(
+                DeltaGlobalCommitter decoratedGlobalCommitter,
+                GlobalCommitterExceptionMode exceptionMode,
+                Set<Integer> checkpointsToFailOn) {
+
+            super(decoratedGlobalCommitter);
+            this.exceptionMode = exceptionMode;
+            this.checkpointsToFailOn = checkpointsToFailOn;
+        }
+
+        @Override
+        public List<DeltaGlobalCommittable> commit(List<DeltaGlobalCommittable> list)
+            throws IOException, InterruptedException {
+
+            checkpointCounter++;
+
+            switch (exceptionMode) {
+                case BEFORE_COMMIT:
+                    if (checkpointsToFailOn.contains(checkpointCounter)) {
+                        designExceptionCounter++;
+                        throw new RuntimeException("Designed Exception from Global Committer BEFORE"
+                            + " Delta log commit.");
+                    }
+                    return this.decoratedGlobalCommitter.commit(list);
+                case AFTER_COMMIT:
+                    List<DeltaGlobalCommittable> commit =
+                        this.decoratedGlobalCommitter.commit(list);
+                    if (checkpointsToFailOn.contains(checkpointCounter)) {
+                        designExceptionCounter++;
+                        throw new RuntimeException("Designed Exception from Global Committer AFTER"
+                            + " Delta log commit.");
+                    }
+                    return commit;
+                case NONE:
+                    return this.decoratedGlobalCommitter.commit(list);
+                default:
+                    throw new RuntimeException("Unexpected Exception mode");
+            }
+        }
+
+        /**
+         * Reset static fields since those are initialized only once per entire JVM.
+         */
+        public static void reset() {
+            checkpointCounter = 0;
+            designExceptionCounter = 0;
         }
     }
 }

--- a/flink/src/test/java/io/delta/flink/sink/internal/committer/DeltaGlobalCommitterTestParametrized.java
+++ b/flink/src/test/java/io/delta/flink/sink/internal/committer/DeltaGlobalCommitterTestParametrized.java
@@ -88,6 +88,7 @@ public class DeltaGlobalCommitterTestParametrized {
     private RowType rowTypeToCommit;
 
     private Path tablePath;
+
     private DeltaLog deltaLog;
 
     @Before

--- a/flink/src/test/java/io/delta/flink/sink/utils/DeltaSinkTestUtils.java
+++ b/flink/src/test/java/io/delta/flink/sink/utils/DeltaSinkTestUtils.java
@@ -151,10 +151,39 @@ public class DeltaSinkTestUtils {
     }
 
     public static DeltaPendingFile getTestDeltaPendingFile(
-        LinkedHashMap<String, String> partitionSpec) {
+            LinkedHashMap<String, String> partitionSpec) {
         return new DeltaPendingFile(
             partitionSpec,
             "file_name-" + UUID.randomUUID(),
+            new FileSinkTestUtils.TestPendingFileRecoverable(),
+            new Random().nextInt(30000),
+            new Random().nextInt(500000),
+            System.currentTimeMillis()
+        );
+    }
+
+    public static DeltaPendingFile getTestDeltaPendingFileWithAbsolutePath(
+            org.apache.hadoop.fs.Path basePath,
+            LinkedHashMap<String, String> partitionSpec) {
+
+        return new DeltaPendingFile(
+            partitionSpec,
+            ((basePath.toString().endsWith("/")) ? basePath.toString() : basePath + "/")
+            + "file_name-" + UUID.randomUUID(),
+            new FileSinkTestUtils.TestPendingFileRecoverable(),
+            new Random().nextInt(30000),
+            new Random().nextInt(500000),
+            System.currentTimeMillis()
+        );
+    }
+
+    public static DeltaPendingFile getTestDeltaPendingFileForFileName(
+        String fileName,
+        LinkedHashMap<String, String> partitionSpec) {
+
+        return new DeltaPendingFile(
+            partitionSpec,
+            fileName,
             new FileSinkTestUtils.TestPendingFileRecoverable(),
             new Random().nextInt(30000),
             new Random().nextInt(500000),

--- a/flink/src/test/java/io/delta/flink/sink/utils/DeltaSinkTestUtils.java
+++ b/flink/src/test/java/io/delta/flink/sink/utils/DeltaSinkTestUtils.java
@@ -110,9 +110,7 @@ public class DeltaSinkTestUtils {
         return rows;
     }
 
-    public static RowData getTestRowDataEvent(String name,
-                                              String surname,
-                                              Integer age) {
+    public static RowData getTestRowDataEvent(String name, String surname, Integer age) {
         return TEST_ROW_TYPE_CONVERTER.toInternal(Row.of(name, surname, age));
     }
 
@@ -329,8 +327,10 @@ public class DeltaSinkTestUtils {
     // IT case utils
     ///////////////////////////////////////////////////////////////////////////
 
-    public static DeltaSinkInternal<RowData> createDeltaSink(String deltaTablePath,
-                                                             boolean isTablePartitioned) {
+    public static DeltaSinkInternal<RowData> createDeltaSink(
+            String deltaTablePath,
+            boolean isTablePartitioned) {
+
         if (isTablePartitioned) {
             DeltaSinkBuilder<RowData> builder = new DeltaSinkBuilder.DefaultDeltaFormatBuilder<>(
                 new Path(deltaTablePath),

--- a/project/StandaloneMimaExcludes.scala
+++ b/project/StandaloneMimaExcludes.scala
@@ -44,7 +44,10 @@ object StandaloneMimaExcludes {
 
     // ParquetSchemaConverter etc. were moved to project standalone-parquet
     ProblemFilters.exclude[MissingClassProblem]("io.delta.standalone.util.ParquetSchemaConverter"),
-    ProblemFilters.exclude[MissingClassProblem]("io.delta.standalone.util.ParquetSchemaConverter$ParquetOutputTimestampType")
+    ProblemFilters.exclude[MissingClassProblem]("io.delta.standalone.util.ParquetSchemaConverter$ParquetOutputTimestampType"),
+
+    // Public API changes in 0.5.0 -> 0.6.0
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("io.delta.standalone.OptimisticTransaction.readVersion"),
 
     // scalastyle:on line.size.limit
   )

--- a/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
+++ b/standalone/src/main/java/io/delta/standalone/OptimisticTransaction.java
@@ -122,4 +122,9 @@ public interface OptimisticTransaction {
      *         transaction.
      */
     Metadata metadata();
+
+    /**
+     * @return The table version that this transaction is reading from.
+     */
+    long readVersion();
 }

--- a/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
+++ b/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
@@ -86,9 +86,6 @@ private[internal] class OptimisticTransactionImpl(
    */
   def metadataScala: Metadata = newMetadata.getOrElse(snapshot.metadataScala)
 
-  /** The version that this transaction is reading from. */
-  private def readVersion: Long = snapshot.version
-
   ///////////////////////////////////////////////////////////////////////////
   // Public Java API Methods
   ///////////////////////////////////////////////////////////////////////////
@@ -222,6 +219,10 @@ private[internal] class OptimisticTransactionImpl(
   override def txnVersion(id: String): Long = {
     readTxn += id
     snapshot.transactions.getOrElse(id, -1L)
+  }
+
+  override def readVersion(): Long = {
+    snapshot.version
   }
 
   ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
fix data loss on Delta Sink due to skipping late RPC calls to GlobalCommitter.

Signed-off-by: Krzysztof Chmielewski <krzysiek.chmielewski@gmail.com>